### PR TITLE
refactor: change PackageVersion to have static and instance methods

### DIFF
--- a/messages/package_version.md
+++ b/messages/package_version.md
@@ -1,3 +1,7 @@
 # errorInvalidIdNoMatchingVersionId
 
 The %s %s is invalid, as a corresponding %s was not found
+
+# errorInvalidPackageVersionId
+
+The provided alias or ID: [%s] could not be resolved to a valid package version ID (05i) or subscriber package version ID (04t).

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -261,6 +261,13 @@ export type MDFolderForArtifactOptions = {
 
 export type PackageVersionOptions = {
   connection: Connection;
+  /**
+   * Can be one of:
+   * 1. SubscriberPackageVersionId (04t)
+   * 2. PackageVersionId (05i)
+   * 3. Alias for a 04t or 05i, defined in sfdx-project.json
+   */
+  idOrAlias: string;
   project: SfProject;
 };
 

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -278,31 +278,32 @@ export type ConvertPackageOptions = {
   buildInstance: string;
 };
 
-export type PackageVersionCreateOptions = Partial<
-  PackageVersionOptions & {
-    branch: string;
-    buildinstance: string;
-    codecoverage: boolean;
-    definitionfile: string;
-    installationkey: string;
-    installationkeybypass: boolean;
-    packageId: string;
-    postinstallscript: string;
-    postinstallurl: string;
-    preserve: boolean;
-    releasenotesurl: string;
-    skipancestorcheck: boolean;
-    skipvalidation: boolean;
-    sourceorg: string;
-    tag: string;
-    uninstallscript: string;
-    validateschema: boolean;
-    versiondescription: string;
-    versionname: string;
-    versionnumber: string;
-    profileApi: PackageProfileApi;
-  }
->;
+export type PackageVersionCreateOptions = {
+  connection: Connection;
+  project: SfProject;
+} & Partial<{
+  branch: string;
+  buildinstance: string;
+  codecoverage: boolean;
+  definitionfile: string;
+  installationkey: string;
+  installationkeybypass: boolean;
+  packageId: string;
+  postinstallscript: string;
+  postinstallurl: string;
+  preserve: boolean;
+  releasenotesurl: string;
+  skipancestorcheck: boolean;
+  skipvalidation: boolean;
+  sourceorg: string;
+  tag: string;
+  uninstallscript: string;
+  validateschema: boolean;
+  versiondescription: string;
+  versionname: string;
+  versionnumber: string;
+  profileApi: PackageProfileApi;
+}>;
 
 export type PackageVersionCreateRequestQueryOptions = {
   createdlastdays?: number;

--- a/src/package/packageVersionReport.ts
+++ b/src/package/packageVersionReport.ts
@@ -77,24 +77,14 @@ async function getPackageVersionStrings(
 }
 
 export async function getPackageVersionReport(options: {
-  idOrAlias: string;
+  packageVersionId: string;
   connection: Connection;
   project: SfProject;
   verbose: boolean;
 }): Promise<PackageVersionReportResult[]> {
   logger.debug(`entering getPackageVersionReport(${util.inspect(options, { depth: null })})`);
-  let packageVersionId = pkgUtils.getPackageIdFromAlias(options.idOrAlias, options.project);
-
-  // ID can be an 04t or 05i
-  pkgUtils.validateId(
-    [pkgUtils.BY_LABEL.SUBSCRIBER_PACKAGE_VERSION_ID, pkgUtils.BY_LABEL.PACKAGE_VERSION_ID],
-    packageVersionId
-  );
-
-  // lookup the 05i ID, if needed
-  packageVersionId = await pkgUtils.getPackageVersionId(packageVersionId, options.connection);
   const queryResult = await options.connection.tooling.query<PackageVersionReportResult>(
-    util.format(options.verbose ? QUERY_VERBOSE : QUERY, packageVersionId)
+    util.format(options.verbose ? QUERY_VERBOSE : QUERY, options.packageVersionId)
   );
   const records = queryResult.records;
   if (records?.length > 0) {

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -127,6 +127,8 @@ describe('Integration tests for @salesforce/packaging library', function () {
 
     it('package version create', async () => {
       const result = await PackageVersion.create({
+        connection: devHubOrg.getConnection(),
+        project,
         packageId: pkgId,
         tag: TAG,
         codecoverage: true,

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -126,8 +126,7 @@ describe('Integration tests for @salesforce/packaging library', function () {
     });
 
     it('package version create', async () => {
-      const pv = new PackageVersion({ project, connection: devHubOrg.getConnection() });
-      const result = await pv.create({
+      const result = await PackageVersion.create({
         packageId: pkgId,
         tag: TAG,
         codecoverage: true,
@@ -146,9 +145,8 @@ describe('Integration tests for @salesforce/packaging library', function () {
       pkgId = result.Package2Id;
     });
 
-    it('get package version create report', async () => {
-      const pv = new PackageVersion({ project, connection: devHubOrg.getConnection() });
-      const result = await pv.getCreateVersionReport(pkgCreateVersionRequestId);
+    it('get package version create status', async () => {
+      const result = await PackageVersion.getCreateStatus(pkgCreateVersionRequestId, devHubOrg.getConnection());
       expect(result).to.include.keys(VERSION_CREATE_RESPONSE_KEYS);
 
       if (result.Status === 'Error') {
@@ -156,8 +154,7 @@ describe('Integration tests for @salesforce/packaging library', function () {
       }
     });
 
-    it('wait for package version create to finish', async () => {
-      const pv = new PackageVersion({ project, connection: devHubOrg.getConnection() });
+    it('poll for package version create to finish', async () => {
       // "enqueued", "in-progress", "success", "error" and "timed-out"
       Lifecycle.getInstance().on(
         PackageVersionEvents.create.enqueued,
@@ -179,10 +176,12 @@ describe('Integration tests for @salesforce/packaging library', function () {
           expect(results.Status).to.equal(PackagingSObjects.Package2VersionStatus.success);
         }
       );
-      const result = await pv.waitForCreateVersion(pkgCreateVersionRequestId, {
-        frequency: Duration.seconds(30),
-        timeout: Duration.minutes(20),
-      });
+      const result = await PackageVersion.pollCreateStatus(
+        pkgCreateVersionRequestId,
+        devHubOrg.getConnection(),
+        project,
+        { frequency: Duration.seconds(30), timeout: Duration.minutes(20) }
+      );
       expect(result).to.include.keys(VERSION_CREATE_RESPONSE_KEYS);
 
       subscriberPkgVersionId = result.SubscriberPackageVersionId;
@@ -204,9 +203,13 @@ describe('Integration tests for @salesforce/packaging library', function () {
       ).to.have.length(1);
     });
 
-    it('force:package:version:report', async () => {
-      const pv = new PackageVersion({ project, connection: devHubOrg.getConnection() });
-      const result = await pv.report(subscriberPkgVersionId);
+    it('package version report', async () => {
+      const pv = new PackageVersion({
+        project,
+        connection: devHubOrg.getConnection(),
+        idOrAlias: subscriberPkgVersionId,
+      });
+      const result = await pv.report();
 
       expect(result).to.not.have.property('Id');
       expect(result.Package2Id).to.equal(
@@ -245,8 +248,12 @@ describe('Integration tests for @salesforce/packaging library', function () {
     });
 
     it('will update the package version with a new branch', async () => {
-      const pv = new PackageVersion({ connection: devHubOrg.getConnection(), project });
-      const result = await pv.update(subscriberPkgVersionId, { Branch: 'superFunBranch' });
+      const pv = new PackageVersion({
+        project,
+        connection: devHubOrg.getConnection(),
+        idOrAlias: subscriberPkgVersionId,
+      });
+      const result = await pv.update({ Branch: 'superFunBranch' });
       expect(result).to.include.keys('id', 'success', 'errors');
       expect(result.id.startsWith('04t')).to.be.true;
       expect(result.success).to.be.true;
@@ -254,8 +261,12 @@ describe('Integration tests for @salesforce/packaging library', function () {
     });
 
     it('will promote the package version', async () => {
-      const pvc = new PackageVersion({ connection: devHubOrg.getConnection(), project });
-      const result = await pvc.promote(subscriberPkgVersionId);
+      const pv = new PackageVersion({
+        project,
+        connection: devHubOrg.getConnection(),
+        idOrAlias: subscriberPkgVersionId,
+      });
+      const result = await pv.promote();
       expect(result).to.have.all.keys('id', 'success', 'errors');
     });
 
@@ -269,8 +280,7 @@ describe('Integration tests for @salesforce/packaging library', function () {
     });
 
     it('will list all of the created package versions', async () => {
-      const pkg = new PackageVersion({ connection: devHubOrg.getConnection(), project });
-      const result = await pkg.createdList();
+      const result = await PackageVersion.createdList(devHubOrg.getConnection());
       expect(result).to.have.length.at.least(1);
       expect(result[0]).to.have.all.keys(
         'Id',
@@ -292,8 +302,7 @@ describe('Integration tests for @salesforce/packaging library', function () {
     });
 
     it('will list all of the created package versions (status = error)', async () => {
-      const pkg = new PackageVersion({ connection: devHubOrg.getConnection(), project });
-      const result = await pkg.createdList({ status: 'Success' });
+      const result = await PackageVersion.createdList(devHubOrg.getConnection(), { status: 'Success' });
       result.map((res) => {
         // we should've filtered to only successful package versions1
         expect(res.Status).to.equal('Success');
@@ -301,8 +310,7 @@ describe('Integration tests for @salesforce/packaging library', function () {
     });
 
     it('will list all of the created package versions (createdLastDays = 3)', async () => {
-      const pkg = new PackageVersion({ connection: devHubOrg.getConnection(), project });
-      const result = await pkg.createdList({ createdlastdays: 3 });
+      const result = await PackageVersion.createdList(devHubOrg.getConnection(), { createdlastdays: 3 });
       expect(result).to.have.length.at.least(1);
       expect(result[0]).to.have.all.keys(
         'Id',
@@ -453,8 +461,12 @@ describe('Integration tests for @salesforce/packaging library', function () {
 
   describe('delete package/version from the devhub', () => {
     it('deletes the package version', async () => {
-      const pv = new PackageVersion({ project, connection: devHubOrg.getConnection() });
-      const result = await pv.delete(subscriberPkgVersionId);
+      const pv = new PackageVersion({
+        project,
+        connection: devHubOrg.getConnection(),
+        idOrAlias: subscriberPkgVersionId,
+      });
+      const result = await pv.delete();
       expect(result.success).to.be.true;
       expect(result.id).to.equal(subscriberPkgVersionId);
     });

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -393,7 +393,7 @@ describe('Package Version Create', () => {
   describe('validateAncestorId', () => {
     let pvc: PackageVersionCreate;
     beforeEach(() => {
-      pvc = new PackageVersionCreate({});
+      pvc = new PackageVersionCreate({ connection, project, packageId });
     });
     it('should throw if the explicitUseNoAncestor is true and highestReleasedVersion is not undefined', () => {
       const ancestorId = 'ancestorId';
@@ -481,7 +481,7 @@ describe('Package Version Create', () => {
   describe('massageErrorMessage', () => {
     let pvc: PackageVersionCreate;
     beforeEach(() => {
-      pvc = new PackageVersionCreate({});
+      pvc = new PackageVersionCreate({ connection, project, packageId });
     });
     it('should return the correct error message', () => {
       const error = new Error();
@@ -493,7 +493,7 @@ describe('Package Version Create', () => {
   describe('validateVersionNumber', () => {
     let pvc: PackageVersionCreate;
     beforeEach(() => {
-      pvc = new PackageVersionCreate({});
+      pvc = new PackageVersionCreate({ connection, project, packageId });
     });
     it('should return version number as valid', () => {
       const versionNumber = pvc['validateVersionNumber']('1.2.3.NEXT', 'NEXT', 'LATEST');


### PR DESCRIPTION
Changes `PackageVersion` to be more of a proper class than a collection of utility functions.  Creating an instance of the class will have meaningful methods.  Static methods are used when there isn't enough information to return an instance such as when creating a new package version.

E.g.,
```
const pkgVersion = new PackageVersion({ connection, project, idOrAlias });
await pkgVersion.delete();
```
or
`PackageVersion.create({ options });`

@W-11819142@