### PR TITLE
refactor: change list function to be static

### DIFF
--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -231,6 +231,28 @@ export class PackageVersion {
     }
   }
 
+  public static async list(
+    connection: Connection,
+    project: SfProject,
+    options: PackageVersionListOptions
+  ): Promise<PackageVersionListResult[]> {
+    // resolve/verify packages
+    const packages = options.packages.map((pkg) => {
+      const id = getPackageIdFromAlias(pkg, project);
+
+      // validate ID
+      if (id.startsWith('0Ho')) {
+        validateId(BY_LABEL.PACKAGE_ID, id);
+        return id;
+      } else {
+        throw messages.createError('errorInvalidPackageVersionId', [id]);
+      }
+    });
+    options.packages = packages;
+
+    return (await listPackageVersions({ ...options, ...{ connection } })).records;
+  }
+
   /**
    * Get the package version ID for this PackageVersion.
    *
@@ -331,10 +353,6 @@ export class PackageVersion {
 
   public install(): Promise<void> {
     return Promise.resolve(undefined);
-  }
-
-  public async list(options: PackageVersionListOptions): Promise<PackageVersionListResult[]> {
-    return (await listPackageVersions({ ...options, ...{ connection: this.connection } })).records;
   }
 
   public uninstall(): Promise<void> {


### PR DESCRIPTION
Changes the `list` function, which returns a list of matching PackageVersions given an array of 0Ho (or aliases) and filtering options, to be static and take additional args for Connection and SfProject.  This is necessary to adopt the PackageVersion refactoring effort in the plugin.

@W-11819142@