### PR TITLE
test: stub SDR's convert method, add arguments for polling override

### DIFF
--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -272,6 +272,7 @@ export type ConvertPackageOptions = {
   installationKeyBypass: boolean;
   wait: Duration;
   buildInstance: string;
+  frequency?: Duration;
 };
 
 export type PackageVersionCreateOptions = {

--- a/src/package/packageConvert.ts
+++ b/src/package/packageConvert.ts
@@ -122,7 +122,7 @@ export async function convertPackage(
       branch,
       project,
       connection,
-      new Duration(pkgUtils.POLL_INTERVAL_SECONDS, Duration.Unit.SECONDS)
+      options.frequency ?? Duration.seconds(pkgUtils.POLL_INTERVAL_SECONDS)
     );
   } else {
     results = await byId(packageId, connection);

--- a/test/package/packageConvert.test.ts
+++ b/test/package/packageConvert.test.ts
@@ -218,7 +218,7 @@ describe('packageConvert', () => {
           Tag: undefined,
         },
         timeRemaining: {
-          quantity: 60,
+          quantity: 2,
           unit: 2,
         },
       });
@@ -252,10 +252,11 @@ describe('packageConvert', () => {
       definitionfile: '',
       installationKeyBypass: true,
       wait: Duration.minutes(1),
+      frequency: Duration.seconds(1),
     });
 
     expect(result).to.deep.equal(successResponse);
-  }).timeout(100000);
+  });
 
   it('will convert the package and handle error on reporting', async () => {
     const conn = await testOrg.getConnection();
@@ -294,5 +295,5 @@ describe('packageConvert', () => {
       expect(message).to.include('(1) Server polling error 1');
       expect(message).to.include('(2) server error 2');
     }
-  }).timeout(100000);
+  });
 });

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -10,7 +10,7 @@ import { instantiateContext, MockTestOrgData, restoreContext, stubContext } from
 import { expect } from 'chai';
 import { Connection, SfProject } from '@salesforce/core';
 import * as xml2js from 'xml2js';
-
+import { stubMethod } from '@salesforce/ts-sinon';
 import { PackageVersionCreate } from '../../src/package/packageVersionCreate';
 import { PackagingSObjects } from '../../src/interfaces';
 
@@ -23,8 +23,17 @@ describe('Package Version Create', () => {
   let packageCreateStub: sinon.SinonStub;
   let xml2jsStub: sinon.SinonStub;
   let pvcStub: sinon.SinonStub;
-
   let project: SfProject;
+
+  // we can't stub all converts in the before each because each test has a unique PVC with different options
+  const stubConvert = (pvc: PackageVersionCreate): void => {
+    $$.SANDBOX.stub(fs, 'existsSync').returns(true);
+    $$.SANDBOX.stub(fs.promises, 'readFile').resolves();
+    stubMethod($$.SANDBOX, pvc, 'convertMetadata').resolves({
+      packagePath: '/var/folders/lc/yk0hz4l50kq0vs79yb3m_lmm0000gp/T/0Ho3i000000Gmj6XXX-TESTING/md-files',
+      converted: [],
+    });
+  };
 
   beforeEach(async () => {
     $$.inProject(true);
@@ -96,7 +105,6 @@ describe('Package Version Create', () => {
       packageAliases: {},
     });
     const pvc = new PackageVersionCreate({ connection, project, packageId });
-
     try {
       await pvc.createPackageVersion();
     } catch (e) {
@@ -111,6 +119,7 @@ describe('Package Version Create', () => {
     xml2jsStub.restore();
     xml2jsStub = $$.SANDBOX.stub(xml2js, 'parseStringPromise').resolves({});
     const pvc = new PackageVersionCreate({ connection, project, packageId });
+    stubConvert(pvc);
 
     try {
       await pvc.createPackageVersion();
@@ -121,6 +130,8 @@ describe('Package Version Create', () => {
 
   it('should create the package version create request', async () => {
     const pvc = new PackageVersionCreate({ connection, project, packageId });
+    stubConvert(pvc);
+
     const result = await pvc.createPackageVersion();
     expect(result).to.have.all.keys(
       'Branch',
@@ -175,6 +186,8 @@ describe('Package Version Create', () => {
 
   it('should create the package version create request with codecoverage=false', async () => {
     const pvc = new PackageVersionCreate({ connection, project, codecoverage: false, packageId });
+    stubConvert(pvc);
+
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].CalculateCodeCoverage).to.equal(false);
     expect(result).to.have.all.keys(
@@ -199,6 +212,8 @@ describe('Package Version Create', () => {
       tag: 'DancingBears',
       packageId,
     });
+    stubConvert(pvc);
+
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Tag).to.equal('DancingBears');
     expect(result).to.have.all.keys(
@@ -224,6 +239,8 @@ describe('Package Version Create', () => {
       packageId,
       skipancestorcheck: true,
     });
+    stubConvert(pvc);
+
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].skipancestorcheck).to.equal(undefined);
     expect(result).to.have.all.keys(
@@ -248,6 +265,8 @@ describe('Package Version Create', () => {
       skipvalidation: true,
       packageId,
     });
+    stubConvert(pvc);
+
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].SkipValidation).to.equal(true);
     expect(result).to.have.all.keys(
@@ -272,6 +291,8 @@ describe('Package Version Create', () => {
       installationkey: 'guessMyPassword',
       packageId,
     });
+    stubConvert(pvc);
+
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].InstallKey).to.equal('guessMyPassword');
     expect(packageCreateStub.firstCall.args[1].SkipValidation).to.equal(false);
@@ -292,6 +313,7 @@ describe('Package Version Create', () => {
 
   it('should create the package version create request with branch', async () => {
     const pvc = new PackageVersionCreate({ connection, project, branch: 'main', packageId });
+    stubConvert(pvc);
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Branch).to.equal('main');
     expect(result).to.have.all.keys(
@@ -322,6 +344,8 @@ describe('Package Version Create', () => {
       postinstallscript: 'myScript.sh',
       packageId,
     });
+    stubConvert(pvc);
+
     try {
       await pvc.createPackageVersion();
     } catch (e) {
@@ -345,6 +369,8 @@ describe('Package Version Create', () => {
       uninstallscript: 'myScript.sh',
       packageId,
     });
+    stubConvert(pvc);
+
     try {
       await pvc.createPackageVersion();
     } catch (e) {
@@ -421,6 +447,8 @@ describe('Package Version Create', () => {
       validateschema: true,
       packageId,
     });
+    stubConvert(pvc);
+
     const result = await pvc.createPackageVersion();
     expect(validationSpy.callCount).to.equal(1);
     expect(result).to.have.all.keys(

--- a/test/package/uninstallPackage.test.ts
+++ b/test/package/uninstallPackage.test.ts
@@ -99,7 +99,7 @@ describe('Package Uninstall', () => {
       expect(error.message).to.include('(2) this is a second error message');
       expect(error.actions).to.deep.equal(['Verify installed package ID and resolve errors, then try again.']);
     }
-  }).timeout(10000);
+  });
 
   it('should send the uninstall request, and handle errors appropriately (0 error messages)', async () => {
     sobjectStub.onSecondCall().returns({
@@ -125,7 +125,7 @@ describe('Package Uninstall', () => {
       );
       expect((e as SfError).actions).to.deep.equal(['Verify installed package ID and resolve errors, then try again.']);
     }
-  }).timeout(10000);
+  });
 
   it('should send the uninstall request, retrieve the status and return', async () => {
     sobjectStub.onSecondCall().returns({


### PR DESCRIPTION
@W-11975912@

stubs `SDR.convert` which was taking a while on the PVC UTs
adds an option to bypass the default polling of 5 seconds for another operation to increase UT speed

went from ~70s to ~13s 🎉 