### PR TITLE
fix: add repl script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ test_session**
 # generated docs
 docs
 
+# history for repl script
+.repl_history
+
 # -- CLEAN ALL
 node_modules
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepack": "sf-prepack",
     "prepare": "sf-install",
     "pretest": "sf-compile-test",
+    "repl": "node --inspect ./scripts/repl.js",
     "test": "sf-test",
     "test:nuts": "nyc mocha \"**/*.nut.ts\" --slow 4500 --timeout 1800000 --parallel"
   },

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const repl = require('repl');
+const { Org, SfProject } = require('@salesforce/core');
+const { Package, PackageVersion, SubscriberPackageVersion, Package1Version } = require('../lib/exported');
+
+const startMessage = `
+Usage:
+  // Get an org Connection
+  const conn = await getConnection(username);
+
+  // Get an SfProject
+  const project = SfProject.getInstance(projectPath);
+
+  // Use the Connection and SfProject when calling methods of:
+    * Package
+    * PackageVersion
+    * SubscriberPackageVersion
+    * Package1Version
+`;
+console.log(startMessage);
+
+const replServer = repl.start({ breakEvalOnSigint: true });
+replServer.setupHistory('.repl_history', (err, repl) => {});
+
+const context = {
+  Package,
+  PackageVersion,
+  SubscriberPackageVersion,
+  Package1Version,
+  SfProject,
+  getConnection: async (username) => {
+    const org = await Org.create({ aliasOrUsername: username });
+    return org.getConnection();
+  },
+};
+
+Object.assign(replServer.context, context);


### PR DESCRIPTION
Adds a repl script for easy API testing.

@W-11949409@

Run it via `yarn repl`.  It starts a debugger for attachment and makes the 4 main classes available for testing.  It's also simple to get an org connection and SfProject instance for use with the APIs.