### PR TITLE
fix: do not add language from org descriptor to pvc request object

### DIFF
--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -309,8 +309,7 @@ export class PackageVersionCreate {
 
     // Ensure we only include the Language property for a connection api version
     // of v57.0 or higher.
-    const apiVersion = this.connection.getApiVersion();
-    if (apiVersion && apiVersion < '57.0') {
+    if (this.connection.getApiVersion() < '57.0') {
       if (requestObject.Language) {
         this.logger.warn(
           `The language option is only valid for API version 57.0 and higher. Ignoring ${requestObject.Language}`

--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -307,6 +307,18 @@ export class PackageVersionCreate {
       Language: this.options.language,
     };
 
+    // Ensure we only include the Language property for a connection api version
+    // of v57.0 or higher.
+    const apiVersion = this.connection.getApiVersion();
+    if (apiVersion && apiVersion < '57.0') {
+      if (requestObject.Language) {
+        this.logger.warn(
+          `The language option is only valid for API version 57.0 and higher. Ignoring ${requestObject.Language}`
+        );
+      }
+      delete requestObject.Language;
+    }
+
     if (preserveFiles) {
       const message = messages.getMessage('tempFileLocation', [packageVersTmpRoot]);
       await Lifecycle.getInstance().emit(PackageVersionEvents.create['preserve-files'], {
@@ -380,16 +392,14 @@ export class PackageVersionCreate {
         throw messages.createError('signupDuplicateSettingsSpecified');
       }
 
-      ['country', 'edition', 'language', 'features', 'orgPreferences', 'snapshot', 'release', 'sourceOrg'].forEach(
-        (prop) => {
+      ['country', 'edition', 'features', 'orgPreferences', 'snapshot', 'release', 'sourceOrg'].forEach((prop) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const propValue = definitionFileJson[prop];
+        if (propValue) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const propValue = definitionFileJson[prop];
-          if (propValue) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            packageDescriptorJson[prop] = propValue;
-          }
+          packageDescriptorJson[prop] = propValue;
         }
-      );
+      });
     }
 
     this.resolveApexTestPermissions(packageDescriptorJson);

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -331,10 +331,31 @@ describe('Package Version Create', () => {
     );
   });
 
-  it('should create the package version create request with language', async () => {
+  it('should create the package version create request with language and API version >= 57.0', async () => {
+    $$.SANDBOX.stub(connection, 'getApiVersion').returns('57.0');
     const pvc = new PackageVersionCreate({ connection, project, language: 'en_US', packageId });
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Language).to.equal('en_US');
+    expect(result).to.have.all.keys(
+      'Branch',
+      'CreatedBy',
+      'CreatedDate',
+      'Error',
+      'HasMetadataRemoved',
+      'Id',
+      'Package2Id',
+      'Package2VersionId',
+      'Status',
+      'SubscriberPackageVersionId',
+      'Tag'
+    );
+  });
+
+  it('should NOT create the package version create request with language and API version < 57.0', async () => {
+    $$.SANDBOX.stub(connection, 'getApiVersion').returns('56.0');
+    const pvc = new PackageVersionCreate({ connection, project, language: 'en_US', packageId });
+    const result = await pvc.createPackageVersion();
+    expect(packageCreateStub.firstCall.args[1].Language).to.be.undefined;
     expect(result).to.have.all.keys(
       'Branch',
       'CreatedBy',


### PR DESCRIPTION
If a language was defined in an org file descriptor used for a package version create, it would set that as an option on the package version create request.  This fix removes that.

Also, the language option is removed unless an org connection of API version 57.0 or higher is used.

@W-12377800@