### PR TITLE
Ts/seed metadata Added support for seedMetadata to package version create and convert commands

### DIFF
--- a/messages/package_version_create.md
+++ b/messages/package_version_create.md
@@ -20,6 +20,8 @@ Dependency on package %s was resolved to version number %s, branch %s, %s.
 
 # buildNumberResolvedForReleased
 
+export type PackageVersionCreateOptions = {
+
 Dependency on package %s was resolved to the released version number %s, %s.
 
 # noReleaseVersionFound
@@ -41,6 +43,10 @@ You cannot use 'settings' and 'orgPreferences' in your scratch definition file, 
 # errorReadingDefintionFile
 
 There was an error while reading or parsing the provided scratch definition file: %s
+
+# seedMDDirectoryDoesNotExist
+
+Seed metadata directory %s was specified but does not exist.
 
 # unpackagedMDDirectoryDoesNotExist
 

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -162,6 +162,7 @@ export type PackageDescriptorJson = Partial<NamedPackageDir> &
     orgPreferences: string[];
     snapshot: string;
     unpackagedMetadata: NamedPackageDir;
+    seedMetadata: NamedPackageDir;
     apexTestAccess: { permissionSets: string[] | string; permissionSetLicenses: string[] | string };
     permissionSetNames: string[];
     permissionSetLicenseDeveloperNames: string[];
@@ -249,6 +250,7 @@ export type MDFolderForArtifactOptions = {
   sourcePaths?: string[];
   metadataPaths?: string[];
   deploydir?: string;
+  sourceApiVersion?: string;
 };
 
 export type PackageVersionOptions = {
@@ -276,6 +278,7 @@ export type ConvertPackageOptions = {
   wait: Duration;
   buildInstance: string;
   frequency?: Duration;
+  seedMetadata?: string;
 };
 
 export type PackageVersionCreateOptions = {

--- a/test/package/packageConvert.test.ts
+++ b/test/package/packageConvert.test.ts
@@ -17,6 +17,7 @@ import {
   findOrCreatePackage2,
 } from '../../src/package/packageConvert';
 import { PackageEvents } from '../../src/interfaces';
+import { PackageVersionCreateUtil } from '../../src/package/packageVersionCreate';
 
 describe('packageConvert', () => {
   const $$ = instantiateContext();
@@ -71,6 +72,24 @@ describe('packageConvert', () => {
       expect(request).to.have.all.keys('InstallKey', 'Instance', 'IsConversionRequest', 'Package2Id', 'VersionInfo');
       expect(request.InstallKey).to.equal(undefined);
       expect(request.Instance).to.equal(undefined);
+      expect(request.IsConversionRequest).to.equal(true);
+      expect(request.Package2Id).to.equal('0Ho3i000000Gmj6CAC');
+      // the most we can assert about VersionInfo because it is a zip file string representation, which changes with time
+      expect(typeof request.VersionInfo).to.equal('string');
+    });
+
+    it('should return a valid request including seed metadata', async () => {
+      $$.inProject(true);
+      $$.SANDBOX.stub(PackageVersionCreateUtil, 'resolveMetadata').resolves(true);
+
+      const request = await createPackageVersionCreateRequest(
+        { installationkey: '123', buildinstance: 'myInstance', seedmetadata: 'seed' },
+        '0Ho3i000000Gmj6CAC',
+        '54.0'
+      );
+      expect(request).to.have.all.keys('InstallKey', 'Instance', 'IsConversionRequest', 'Package2Id', 'VersionInfo');
+      expect(request.InstallKey).to.equal('123');
+      expect(request.Instance).to.equal('myInstance');
       expect(request.IsConversionRequest).to.equal(true);
       expect(request.Package2Id).to.equal('0Ho3i000000Gmj6CAC');
       // the most we can assert about VersionInfo because it is a zip file string representation, which changes with time


### PR DESCRIPTION
I added support for seedMetadata to the convert and package version create commands. Seed metadata will be used for unpackageable metadata that needs to be installed on an org prior to deploying the packaged metadata.