### PR TITLE
feat: adds support for seed metadata to both the convert and package version create commands

### DIFF
--- a/messages/package_version_create.md
+++ b/messages/package_version_create.md
@@ -42,6 +42,10 @@ You cannot use 'settings' and 'orgPreferences' in your scratch definition file, 
 
 There was an error while reading or parsing the provided scratch definition file: %s
 
+# seedMDDirectoryDoesNotExist
+
+Seed metadata directory %s was specified but does not exist.
+
 # unpackagedMDDirectoryDoesNotExist
 
 Un-packaged metadata directory %s was specified but does not exist.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@oclif/core": "^1.25.0",
     "@salesforce/core": "^3.32.11",
     "@salesforce/kit": "^1.8.3",
-    "@salesforce/schemas": "^1.4.0",
+    "@salesforce/schemas": "^1.5.0",
     "@salesforce/source-deploy-retrieve": "^7.5.19",
     "@salesforce/ts-types": "^1.7.1",
     "@xmldom/xmldom": "^0.8.6",

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -162,6 +162,7 @@ export type PackageDescriptorJson = Partial<NamedPackageDir> &
     orgPreferences: string[];
     snapshot: string;
     unpackagedMetadata: NamedPackageDir;
+    seedMetadata: NamedPackageDir;
     apexTestAccess: { permissionSets: string[] | string; permissionSetLicenses: string[] | string };
     permissionSetNames: string[];
     permissionSetLicenseDeveloperNames: string[];
@@ -249,6 +250,7 @@ export type MDFolderForArtifactOptions = {
   sourcePaths?: string[];
   metadataPaths?: string[];
   deploydir?: string;
+  sourceApiVersion?: string;
 };
 
 export type PackageVersionOptions = {
@@ -276,6 +278,7 @@ export type ConvertPackageOptions = {
   wait: Duration;
   buildInstance: string;
   frequency?: Duration;
+  seedMetadata?: string;
 };
 
 export type PackageVersionCreateOptions = {

--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -58,7 +58,6 @@ import { BuildNumberToken, VersionNumber } from './versionNumber';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/packaging', 'package_version_create');
-
 const DESCRIPTOR_FILE = 'package2-descriptor.json';
 
 export class PackageVersionCreate {
@@ -69,11 +68,13 @@ export class PackageVersionCreate {
   private packageId: string;
   private pkg: Package;
   private readonly logger: Logger;
+  private metadataResolver: MetadataResolver;
 
   public constructor(private options: PackageVersionCreateOptions) {
     this.connection = this.options.connection;
     this.project = this.options.project;
     this.logger = Logger.childFromRoot('packageVersionCreate');
+    this.metadataResolver = new MetadataResolver();
   }
 
   public createPackageVersion(): Promise<Partial<PackageVersionCreateRequestResult>> {
@@ -82,57 +83,6 @@ export class PackageVersionCreate {
     } catch (err) {
       throw pkgUtils.applyErrorAction(pkgUtils.massageErrorMessage(err as Error));
     }
-  }
-
-  /**
-   * Extracted into a method for UT purposes
-   *
-   * @param componentSet CS to convert
-   * @param outputDirectory where to place the converted MD
-   * @param packageName the packagename related to the CS
-   * @private
-   */
-  // eslint-disable-next-line class-methods-use-this
-  private async convertMetadata(
-    componentSet: ComponentSet,
-    outputDirectory: string,
-    packageName: string
-  ): Promise<ConvertResult> {
-    const converter = new MetadataConverter();
-    return converter.convert(componentSet, 'metadata', {
-      type: 'directory',
-      outputDirectory,
-      packageName,
-      genUniqueDir: false,
-    });
-  }
-
-  // convert source to mdapi format and copy to tmp dir packaging up
-  private async generateMDFolderForArtifact(options: MDFolderForArtifactOptions): Promise<ConvertResult> {
-    const sourcepath = options.sourcePaths ?? [options.sourceDir];
-    const componentSet = await ComponentSetBuilder.build({
-      sourceapiversion: this.project.getSfProjectJson().get('sourceApiVersion') as string,
-      sourcepath,
-    });
-    const packageName = options.packageName;
-    const outputDirectory = path.resolve(options.deploydir);
-    const convertResult = await this.convertMetadata(componentSet, outputDirectory, packageName);
-
-    if (packageName) {
-      // SDR will build an output path like /output/directory/packageName/package.xml
-      // this was breaking from toolbelt, so to revert it we copy the directory up a level and delete the original
-      copyDir(convertResult.packagePath, outputDirectory);
-      try {
-        fs.rmSync(convertResult.packagePath, { recursive: true });
-      } catch (e) {
-        // rmdirSync is being deprecated and emits a warning
-        // but rmSync is introduced in node 14 so fall back to rmdirSync
-        fs.rmdirSync(convertResult.packagePath, { recursive: true });
-      }
-
-      convertResult.packagePath = outputDirectory;
-    }
-    return convertResult;
   }
 
   private async validateDependencyValues(dependency: PackageDescriptorJson): Promise<void> {
@@ -343,10 +293,12 @@ export class PackageVersionCreate {
     const packageVersTmpRoot = path.join(os.tmpdir(), `${uniqueHash}`);
     const packageVersMetadataFolder = path.join(packageVersTmpRoot, 'md-files');
     const unpackagedMetadataFolder = path.join(packageVersTmpRoot, 'unpackaged-md-files');
+    const seedMetadataFolder = path.join(packageVersTmpRoot, 'seed-md-files');
     const packageVersProfileFolder = path.join(packageVersMetadataFolder, 'profiles');
     const packageVersBlobDirectory = path.join(packageVersTmpRoot, 'package-version-info');
     const metadataZipFile = path.join(packageVersBlobDirectory, 'package.zip');
     const unpackagedMetadataZipFile = path.join(packageVersBlobDirectory, 'unpackaged-metadata-package.zip');
+    const seedMetadataZipFile = path.join(packageVersBlobDirectory, 'seed-metadata-package.zip');
     const settingsZipFile = path.join(packageVersBlobDirectory, 'settings.zip');
     const packageVersBlobZipFile = path.join(packageVersTmpRoot, 'package-version-info.zip');
     const sourceBaseDir = path.join(this.project.getPath(), this.packageObject.path ?? '');
@@ -354,6 +306,7 @@ export class PackageVersionCreate {
     const mdOptions = {
       deploydir: packageVersMetadataFolder,
       sourceDir: sourceBaseDir,
+      sourceApiVersion: this.project?.getSfProjectJson()?.get('sourceApiVersion') as string,
     };
 
     // Stores any additional client side info that might be needed later on in the process
@@ -362,7 +315,7 @@ export class PackageVersionCreate {
     const settingsGenerator = new SettingsGenerator({ asDirectory: true });
     const packageDescriptorJson = cloneJson(this.packageObject) as PackageDescriptorJson;
     // Copy all the metadata from the workspace to a tmp folder
-    const componentSet = await this.generateMDFolderForArtifact(mdOptions);
+    const componentSet = await this.metadataResolver.generateMDFolderForArtifact(mdOptions);
     this.verifyHasSource(componentSet);
 
     if (packageDescriptorJson.package) {
@@ -446,11 +399,13 @@ export class PackageVersionCreate {
       packageVersMetadataFolder,
       packageVersProfileFolder,
       unpackagedMetadataFolder,
+      seedMetadataFolder,
       metadataZipFile,
       settingsZipFile,
       packageVersBlobDirectory,
       packageVersBlobZipFile,
       unpackagedMetadataZipFile,
+      seedMetadataZipFile,
       clientSideInfo,
       settingsGenerator
     );
@@ -459,7 +414,7 @@ export class PackageVersionCreate {
   }
 
   private verifyHasSource(componentSet: ConvertResult): void {
-    if (componentSet.converted.length === 0) {
+    if (componentSet?.converted.length === 0) {
       throw messages.createError('noSourceInRootDirectory', [this.packageObject.path ?? '<unknown>']);
     }
   }
@@ -468,11 +423,13 @@ export class PackageVersionCreate {
     packageVersMetadataFolder: string,
     packageVersProfileFolder: string,
     unpackagedMetadataFolder: string,
+    seedMetadataFolder: string,
     metadataZipFile: string,
     settingsZipFile: string,
     packageVersBlobDirectory: string,
     packageVersBlobZipFile: string,
     unpackagedMetadataZipFile: string,
+    seedMetadataZipFile: string,
     clientSideInfo: Map<string, string>,
     settingsGenerator: SettingsGenerator
   ): Promise<void> {
@@ -497,18 +454,28 @@ export class PackageVersionCreate {
     let typesArr = packageJson.Package.types;
     this.apiVersionFromPackageXml = packageJson.Package.version;
 
-    const hasUnpackagedMetadata = await this.resolveUnpackagedMetadata(
-      this.packageObject,
-      unpackagedMetadataFolder,
-      clientSideInfo,
-      this.options.codecoverage
+    const sourceApiVersion = this.project?.getSfProjectJson()?.get('sourceApiVersion') as string;
+    const hasSeedMetadata = await this.metadataResolver.resolveMetadata(
+      (this.packageObject as PackageDescriptorJson).seedMetadata?.path,
+      seedMetadataFolder,
+      'seedMDDirectoryDoesNotExist',
+      sourceApiVersion
     );
+
+    let hasUnpackagedMetadata = false;
+    const unpackagedMetadataPath = (this.packageObject as PackageDescriptorJson).unpackagedMetadata?.path;
+    if (this.options.codecoverage) {
+      hasUnpackagedMetadata = await this.metadataResolver.resolveMetadata(
+        unpackagedMetadataPath,
+        unpackagedMetadataFolder,
+        'unpackagedMDDirectoryDoesNotExist',
+        sourceApiVersion
+      );
+    }
 
     // if we're using unpackaged metadata, don't package the profiles located there
     if (hasUnpackagedMetadata) {
-      typesArr = this.options.profileApi.filterAndGenerateProfilesForManifest(typesArr, [
-        clientSideInfo.get('UnpackagedMetadataPath'),
-      ]);
+      typesArr = this.options.profileApi.filterAndGenerateProfilesForManifest(typesArr, [unpackagedMetadataPath]);
     } else {
       typesArr = this.options.profileApi.filterAndGenerateProfilesForManifest(typesArr);
     }
@@ -519,7 +486,7 @@ export class PackageVersionCreate {
       {
         Package: typesArr,
       },
-      [clientSideInfo.get('UnpackagedMetadataPath')]
+      [unpackagedMetadataPath]
     );
 
     if (excludedProfiles.length > 0) {
@@ -548,6 +515,10 @@ export class PackageVersionCreate {
     await fs.promises.writeFile(path.join(packageVersMetadataFolder, 'package.xml'), xml, 'utf-8');
     // Zip the packageVersMetadataFolder folder and put the zip in {packageVersBlobDirectory}/package.zip
     await zipDir(packageVersMetadataFolder, metadataZipFile);
+    if (hasSeedMetadata) {
+      // Zip the seedMetadataFolder folder and put the zip in {packageVersBlobDirectory}/{seedMetadataZipFile}
+      await zipDir(seedMetadataFolder, seedMetadataZipFile);
+    }
     if (hasUnpackagedMetadata) {
       // Zip the unpackagedMetadataFolder folder and put the zip in {packageVersBlobDirectory}/{unpackagedMetadataZipFile}
       await zipDir(unpackagedMetadataFolder, unpackagedMetadataZipFile);
@@ -588,33 +559,6 @@ export class PackageVersionCreate {
     }
 
     delete packageDescriptorJson.apexTestAccess;
-  }
-
-  private async resolveUnpackagedMetadata(
-    packageDescriptorJson: PackageDescriptorJson,
-    unpackagedMetadataFolder: string,
-    clientSideInfo: Map<string, string>,
-    codeCoverage: boolean
-  ): Promise<boolean> {
-    // Add the Unpackaged Metadata, if any, to the output directory, only when code coverage is specified
-    if (codeCoverage && packageDescriptorJson.unpackagedMetadata?.path) {
-      const unpackagedPath = path.join(process.cwd(), packageDescriptorJson.unpackagedMetadata.path);
-      if (!fs.existsSync(unpackagedPath)) {
-        throw messages.createError('unpackagedMDDirectoryDoesNotExist', [
-          packageDescriptorJson.unpackagedMetadata.path,
-        ]);
-      }
-
-      fs.mkdirSync(unpackagedMetadataFolder, { recursive: true });
-      await this.generateMDFolderForArtifact({
-        deploydir: unpackagedMetadataFolder,
-        sourceDir: unpackagedPath,
-      });
-      // Set which package is the "unpackaged" package
-      clientSideInfo.set('UnpackagedMetadataPath', packageDescriptorJson.unpackagedMetadata.path);
-      return true;
-    }
-    return false;
   }
 
   // eslint-disable-next-line complexity
@@ -749,6 +693,7 @@ export class PackageVersionCreate {
     delete packageDescriptorJson.default; // for client-side use only, not needed
     delete packageDescriptorJson.includeProfileUserLicenses; // for client-side use only, not needed
     delete packageDescriptorJson.unpackagedMetadata; // for client-side use only, not needed
+    delete packageDescriptorJson.seedMetadata; // for client-side use only, not needed
     delete packageDescriptorJson.branch; // for client-side use only, not needed
     delete packageDescriptorJson.fullPath; // for client-side use only, not needed
     delete packageDescriptorJson.name; // for client-side use only, not needed
@@ -1067,5 +1012,81 @@ export class PackageVersionCreate {
       }
     }
     return result;
+  }
+}
+
+export class MetadataResolver {
+  public async resolveMetadata(
+    metadataRelativePath: string,
+    metadataOutputPath: string,
+    errorMessageLabel: string,
+    sourceApiVersion?: string
+  ): Promise<boolean> {
+    if (metadataRelativePath) {
+      const metadataFullPath = path.join(process.cwd(), metadataRelativePath);
+      if (!fs.existsSync(metadataFullPath)) {
+        throw messages.createError(errorMessageLabel, [metadataRelativePath]);
+      }
+
+      fs.mkdirSync(metadataOutputPath, { recursive: true });
+      await this.generateMDFolderForArtifact({
+        deploydir: metadataOutputPath,
+        sourceDir: metadataFullPath,
+        sourceApiVersion,
+      });
+      return true;
+    }
+    return false;
+  }
+
+  // convert source to mdapi format and copy to tmp dir packaging up
+  public async generateMDFolderForArtifact(options: MDFolderForArtifactOptions): Promise<ConvertResult> {
+    const sourcepath = options.sourcePaths ?? [options.sourceDir];
+    const componentSet = await ComponentSetBuilder.build({
+      sourceapiversion: options.sourceApiVersion,
+      sourcepath,
+    });
+    const packageName = options.packageName;
+    const outputDirectory = path.resolve(options.deploydir);
+    const convertResult = await this.convertMetadata(componentSet, outputDirectory, packageName);
+
+    if (packageName) {
+      // SDR will build an output path like /output/directory/packageName/package.xml
+      // this was breaking from toolbelt, so to revert it we copy the directory up a level and delete the original
+      copyDir(convertResult.packagePath, outputDirectory);
+      try {
+        fs.rmSync(convertResult.packagePath, { recursive: true });
+      } catch (e) {
+        // rmdirSync is being deprecated and emits a warning
+        // but rmSync is introduced in node 14 so fall back to rmdirSync
+        fs.rmdirSync(convertResult.packagePath, { recursive: true });
+      }
+
+      convertResult.packagePath = outputDirectory;
+    }
+    return convertResult;
+  }
+
+  /**
+   * Extracted into a method for UT purposes
+   *
+   * @param componentSet CS to convert
+   * @param outputDirectory where to place the converted MD
+   * @param packageName the packagename related to the CS
+   * @private
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private async convertMetadata(
+    componentSet: ComponentSet,
+    outputDirectory: string,
+    packageName: string
+  ): Promise<ConvertResult> {
+    const converter = new MetadataConverter();
+    return converter.convert(componentSet, 'metadata', {
+      type: 'directory',
+      outputDirectory,
+      packageName,
+      genUniqueDir: false,
+    });
   }
 }

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -10,8 +10,7 @@ import { instantiateContext, MockTestOrgData, restoreContext, stubContext } from
 import { expect } from 'chai';
 import { Connection, SfProject } from '@salesforce/core';
 import * as xml2js from 'xml2js';
-import { stubMethod } from '@salesforce/ts-sinon';
-import { PackageVersionCreate } from '../../src/package/packageVersionCreate';
+import { PackageVersionCreate, MetadataResolver } from '../../src/package/packageVersionCreate';
 import { PackagingSObjects } from '../../src/interfaces';
 
 describe('Package Version Create', () => {
@@ -26,13 +25,16 @@ describe('Package Version Create', () => {
   let project: SfProject;
 
   // we can't stub all converts in the before each because each test has a unique PVC with different options
-  const stubConvert = (pvc: PackageVersionCreate): void => {
+  const stubConvert = (): void => {
     $$.SANDBOX.stub(fs, 'existsSync').returns(true);
     $$.SANDBOX.stub(fs.promises, 'readFile').resolves();
-    stubMethod($$.SANDBOX, pvc, 'convertMetadata').resolves({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $$.SANDBOX.stub(MetadataResolver.prototype, 'convertMetadata' as any).resolves({
       packagePath: '/var/folders/lc/yk0hz4l50kq0vs79yb3m_lmm0000gp/T/0Ho3i000000Gmj6XXX-TESTING/md-files',
       converted: [],
     });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $$.SANDBOX.stub(MetadataResolver.prototype, 'generateMDFolderForArtifact' as any).resolves();
   };
 
   beforeEach(async () => {
@@ -57,6 +59,9 @@ describe('Package Version Create', () => {
           ancestorId: 'TEST2',
           unpackagedMetadata: {
             path: 'unpackaged',
+          },
+          seedMetadata: {
+            path: 'seed',
           },
           dependencies: [
             {
@@ -119,7 +124,6 @@ describe('Package Version Create', () => {
     xml2jsStub.restore();
     xml2jsStub = $$.SANDBOX.stub(xml2js, 'parseStringPromise').resolves({});
     const pvc = new PackageVersionCreate({ connection, project, packageId });
-    stubConvert(pvc);
 
     try {
       await pvc.createPackageVersion();
@@ -130,7 +134,7 @@ describe('Package Version Create', () => {
 
   it('should create the package version create request', async () => {
     const pvc = new PackageVersionCreate({ connection, project, packageId });
-    stubConvert(pvc);
+    stubConvert();
 
     const result = await pvc.createPackageVersion();
     expect(result).to.have.all.keys(
@@ -156,12 +160,8 @@ describe('Package Version Create', () => {
 
   it('should create the package version create request with codecoverage=true', async () => {
     const pvc = new PackageVersionCreate({ connection, project, codecoverage: true, packageId });
-    // @ts-ignore
-    const hasUnpackagedMdSpy = $$.SANDBOX.spy(pvc, 'resolveUnpackagedMetadata');
-    // @ts-ignore
-    $$.SANDBOX.stub(pvc, 'generateMDFolderForArtifact').resolves();
-    $$.SANDBOX.stub(fs, 'existsSync').returns(true);
-    $$.SANDBOX.stub(fs.promises, 'readFile').resolves();
+    const hasUnpackagedMdSpy = $$.SANDBOX.spy(MetadataResolver.prototype, 'resolveMetadata');
+    stubConvert();
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].CalculateCodeCoverage).to.equal(true);
     expect(result).to.have.all.keys(
@@ -177,16 +177,15 @@ describe('Package Version Create', () => {
       'SubscriberPackageVersionId',
       'Tag'
     );
-    const unpackagedMD = (hasUnpackagedMdSpy.firstCall.args.at(0) as { unpackagedMetadata: Record<string, string> })
-      .unpackagedMetadata;
-    expect(unpackagedMD).to.deep.equal({
-      path: 'unpackaged',
-    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const unpackagedMD = hasUnpackagedMdSpy.secondCall.args[0];
+    expect(unpackagedMD).to.equal('unpackaged');
   });
 
   it('should create the package version create request with codecoverage=false', async () => {
     const pvc = new PackageVersionCreate({ connection, project, codecoverage: false, packageId });
-    stubConvert(pvc);
+    const hasSeedMdSpy = $$.SANDBOX.spy(MetadataResolver.prototype, 'resolveMetadata');
+    stubConvert();
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].CalculateCodeCoverage).to.equal(false);
@@ -203,6 +202,9 @@ describe('Package Version Create', () => {
       'SubscriberPackageVersionId',
       'Tag'
     );
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const hasSeedMd = hasSeedMdSpy.firstCall.args[0];
+    expect(hasSeedMd).to.equal('seed');
   });
 
   it('should create the package version create request with tag info', async () => {
@@ -212,7 +214,7 @@ describe('Package Version Create', () => {
       tag: 'DancingBears',
       packageId,
     });
-    stubConvert(pvc);
+    stubConvert();
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Tag).to.equal('DancingBears');
@@ -239,7 +241,7 @@ describe('Package Version Create', () => {
       packageId,
       skipancestorcheck: true,
     });
-    stubConvert(pvc);
+    stubConvert();
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].skipancestorcheck).to.equal(undefined);
@@ -265,7 +267,7 @@ describe('Package Version Create', () => {
       skipvalidation: true,
       packageId,
     });
-    stubConvert(pvc);
+    stubConvert();
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].SkipValidation).to.equal(true);
@@ -291,7 +293,7 @@ describe('Package Version Create', () => {
       installationkey: 'guessMyPassword',
       packageId,
     });
-    stubConvert(pvc);
+    stubConvert();
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].InstallKey).to.equal('guessMyPassword');
@@ -313,7 +315,7 @@ describe('Package Version Create', () => {
 
   it('should create the package version create request with branch', async () => {
     const pvc = new PackageVersionCreate({ connection, project, branch: 'main', packageId });
-    stubConvert(pvc);
+    stubConvert();
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Branch).to.equal('main');
     expect(result).to.have.all.keys(
@@ -334,6 +336,7 @@ describe('Package Version Create', () => {
   it('should create the package version create request with language and API version >= 57.0', async () => {
     $$.SANDBOX.stub(connection, 'getApiVersion').returns('57.0');
     const pvc = new PackageVersionCreate({ connection, project, language: 'en_US', packageId });
+    stubConvert();
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Language).to.equal('en_US');
     expect(result).to.have.all.keys(
@@ -353,6 +356,7 @@ describe('Package Version Create', () => {
 
   it('should NOT create the package version create request with language and API version < 57.0', async () => {
     $$.SANDBOX.stub(connection, 'getApiVersion').returns('56.0');
+    stubConvert();
     const pvc = new PackageVersionCreate({ connection, project, language: 'en_US', packageId });
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Language).to.be.undefined;
@@ -384,7 +388,7 @@ describe('Package Version Create', () => {
       postinstallscript: 'myScript.sh',
       packageId,
     });
-    stubConvert(pvc);
+    stubConvert();
 
     try {
       await pvc.createPackageVersion();
@@ -409,7 +413,7 @@ describe('Package Version Create', () => {
       uninstallscript: 'myScript.sh',
       packageId,
     });
-    stubConvert(pvc);
+    stubConvert();
 
     try {
       await pvc.createPackageVersion();
@@ -487,7 +491,7 @@ describe('Package Version Create', () => {
       validateschema: true,
       packageId,
     });
-    stubConvert(pvc);
+    stubConvert();
 
     const result = await pvc.createPackageVersion();
     expect(validationSpy.callCount).to.equal(1);


### PR DESCRIPTION
What does this PR do?

Adds optional seedMetadata so unpackageable metadata can be pushed to the build org that the packaged metadata depends on, such as StandardValueSets.
What issues does this PR fix or reference?

@W-12204966@
