### PR TITLE
fix: remove warn options from log message

### DIFF
--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -726,9 +726,7 @@ export class PackageVersionCreate {
             )
           : versionNumber;
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { connection: c, project: p, profileApi: a, ...warnOptions } = options;
-      this.logger.warn(warnOptions, messages.getMessage('defaultVersionName', [packageDescriptorJson.versionName]));
+      this.logger.warn(messages.getMessage('defaultVersionName', [packageDescriptorJson.versionName]));
     }
 
     if (options.releasenotesurl) {


### PR DESCRIPTION
The warnOptions was causing a circular structure when versionName was not in sfdx-project.json.  This removes them, since it's not interesting to see in the logs anyway.

@W-12498587@
https://github.com/forcedotcom/cli/issues/1907