### PR TITLE
@W-12394717@ Update interfaces for PackageInstallRequest API with SkipHandlers

### DIFF
--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -129,6 +129,7 @@ export type PackageInstallCreateRequest = Partial<
     | 'PackageInstallSource'
     | 'Password'
     | 'SecurityType'
+    | 'SkipHandlers'
     | 'UpgradeType'
   >
 > &

--- a/src/interfaces/packagingSObjects.ts
+++ b/src/interfaces/packagingSObjects.ts
@@ -267,6 +267,7 @@ export namespace PackagingSObjects {
     EnableRss: boolean;
     UpgradeType: Nullable<'delete-only' | 'deprecate-only' | 'mixed-mode'>;
     ApexCompileType: Nullable<'all' | 'package'>;
+    SkipHandlers: boolean;
     Status: 'ERROR' | 'IN_PROGRESS' | 'SUCCESS' | 'UNKNOWN';
     Errors: Nullable<SubscriberPackageInstallErrors>;
   };

--- a/test/package/subscriberPackageVersionInstall.test.ts
+++ b/test/package/subscriberPackageVersionInstall.test.ts
@@ -69,6 +69,7 @@ describe('Package Install', () => {
     EnableRss: false,
     UpgradeType: 'mixed-mode',
     ApexCompileType: 'all',
+    SkipHandlers: null,
     Status: 'SUCCESS',
     Errors: null,
   };


### PR DESCRIPTION
@W-12394717@ Update the PackageInstallRequest interfaces to include the new SkipHandlers field. The SkipHandlers field accepts a list of package install handlers that can be optionally skipped in order to improve the performance speed of the install/upgrade. 