### PR TITLE
feat: for expandability, PackageInstallRequest should be a string value

### DIFF
--- a/src/interfaces/packagingSObjects.ts
+++ b/src/interfaces/packagingSObjects.ts
@@ -267,7 +267,7 @@ export namespace PackagingSObjects {
     EnableRss: boolean;
     UpgradeType: Nullable<'delete-only' | 'deprecate-only' | 'mixed-mode'>;
     ApexCompileType: Nullable<'all' | 'package'>;
-    SkipHandlers: boolean;
+    SkipHandlers: string;
     Status: 'ERROR' | 'IN_PROGRESS' | 'SUCCESS' | 'UNKNOWN';
     Errors: Nullable<SubscriberPackageInstallErrors>;
   };


### PR DESCRIPTION
@W-12394717@ PackageInstallRequest SkipHandlers should be a string value in order to accommodate the potential for a list of handlers to skip in the future.