### PR TITLE
fix: skip handlers are nullable

### DIFF
--- a/src/interfaces/packagingSObjects.ts
+++ b/src/interfaces/packagingSObjects.ts
@@ -267,7 +267,7 @@ export namespace PackagingSObjects {
     EnableRss: boolean;
     UpgradeType: Nullable<'delete-only' | 'deprecate-only' | 'mixed-mode'>;
     ApexCompileType: Nullable<'all' | 'package'>;
-    SkipHandlers: string;
+    SkipHandlers: Nullable<string>;
     Status: 'ERROR' | 'IN_PROGRESS' | 'SUCCESS' | 'UNKNOWN';
     Errors: Nullable<SubscriberPackageInstallErrors>;
   };


### PR DESCRIPTION
Change type definition for `PackageInstallRequest.SkipHandlers` to allow null.
@W-00000000@