### PR TITLE
fix: adds support for seed metadata to both the convert and package version create commands

### DIFF
--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -486,7 +486,7 @@ export class PackageVersionCreate {
       {
         Package: typesArr,
       },
-      [unpackagedMetadataPath]
+      [hasUnpackagedMetadata ? unpackagedMetadataPath : null]
     );
 
     if (excludedProfiles.length > 0) {


### PR DESCRIPTION
What does this PR do?

Fixes package version create so profiles are excluded from the unpackaged metadata directory if code coverage is not specified.

@W-12572895@
