### PR TITLE
fix: properly chunk query for getPackageVersionStrings

### DIFF
--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -270,9 +270,8 @@ export async function getPackageVersionStrings(
   // remove any duplicate Ids
   const ids = [...new Set<string>(subscriberPackageVersionIds)];
 
-  const query = `SELECT SubscriberPackageVersionId, MajorVersion, MinorVersion, PatchVersion, BuildNumber FROM Package2Version WHERE SubscriberPackageVersionId IN (${ids
-    .map((id) => `'${id}'`)
-    .join(',')})`;
+  const query =
+    "SELECT SubscriberPackageVersionId, MajorVersion, MinorVersion, PatchVersion, BuildNumber FROM Package2Version WHERE SubscriberPackageVersionId IN ('%IDS%')";
 
   const records = await queryWithInConditionChunking<PackageVersionString>(query, ids, '%IDS%', connection);
   if (records && records.length > 0) {

--- a/test/utils/packageUtils.test.ts
+++ b/test/utils/packageUtils.test.ts
@@ -78,10 +78,7 @@ describe('packageUtils', () => {
       });
 
       // generate a large array of fake subscriber package version IDs
-      const spvs: string[] = [];
-      while (spvs.length < 201) {
-        spvs.push($$.uniqid());
-      }
+      Array.from({ length: 201 }, () => $$.uniqid())
       await getPackageVersionStrings(spvs, conn);
       expect(queryStub.callCount).to.equal(2);
     });

--- a/test/utils/packageUtils.test.ts
+++ b/test/utils/packageUtils.test.ts
@@ -78,7 +78,7 @@ describe('packageUtils', () => {
       });
 
       // generate a large array of fake subscriber package version IDs
-      Array.from({ length: 201 }, () => $$.uniqid())
+      const spvs = Array.from({ length: 201 }, () => $$.uniqid());
       await getPackageVersionStrings(spvs, conn);
       expect(queryStub.callCount).to.equal(2);
     });


### PR DESCRIPTION
Fixes the getPackageVersionStrings() function to properly chunk a large query into multiple, smaller queries when the where clause is too large.

@W-13083719@ 