### PR TITLE
fix: added unit tests to better describe branch version selection behaviour and corrected issues

### DIFF
--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -166,7 +166,7 @@ export class PackageVersionCreate {
     const buildNumber = versionNumber.build;
 
     // use the dependency.branch if present otherwise use the branch of the version being created
-    const branch = dependency.branch === '' ? this.options.branch : dependency.branch;
+    const branch = dependency.branch === undefined ? this.options.branch : dependency.branch;
     const branchString = !branch || branch === '' ? 'null' : `'${branch}'`;
 
     // resolve a build number keyword to an actual number, if needed

--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -166,7 +166,7 @@ export class PackageVersionCreate {
     const buildNumber = versionNumber.build;
 
     // use the dependency.branch if present otherwise use the branch of the version being created
-    const branch = dependency.branch === undefined ? this.options.branch : dependency.branch;
+    const branch = dependency.branch ?? this.options.branch;
     const branchString = !branch || branch === '' ? 'null' : `'${branch}'`;
 
     // resolve a build number keyword to an actual number, if needed


### PR DESCRIPTION
As per @avesolovksyy feedback over [here](https://github.com/forcedotcom/cli/issues/2183) I have added 2 additional unit tests which I believe better describe the intended behaviour and amended the branch checking condition to resolve the regressions.