### PR TITLE
fix: prevent profile being filtered out from the package

### DIFF
--- a/src/package/packageProfileApi.ts
+++ b/src/package/packageProfileApi.ts
@@ -150,7 +150,7 @@ export class PackageProfileApi extends AsyncCreatable<ProfileApiOptions> {
                 members,
                 profileNode,
                 profileName
-              ) ?? hasNodes;
+              ) || hasNodes;
           }
         });
 
@@ -168,7 +168,7 @@ export class PackageProfileApi extends AsyncCreatable<ProfileApiOptions> {
                 allMembers,
                 profileNode,
                 profileName
-              ) ?? hasNodes;
+              ) || hasNodes;
           }
         });
 


### PR DESCRIPTION
@W-13652536@ CLI regression causes version:create to fail if Admin.profile was previously in the package.