### PR TITLE
fix: use default polling freq

### DIFF
--- a/src/package/packageInstall.ts
+++ b/src/package/packageInstall.ts
@@ -197,9 +197,8 @@ export async function pollStatus(
   let packageInstallRequest = await getStatus(connection, installRequestId);
 
   const { pollingFrequency, pollingTimeout } = options;
-  const frequency = numberToDuration(pollingFrequency);
-
-  const timeout = numberToDuration(pollingTimeout);
+  const frequency = numberToDuration(pollingFrequency ?? 5000);
+  const timeout = numberToDuration(pollingTimeout ?? 300000);
 
   const pollingOptions: PollingClient.Options = {
     frequency,


### PR DESCRIPTION
> the freq is set in the plugin now, so this PR isn't required to close the gh issue.  This change is to prevent other library consumers from hitting the same bug the plugin was.

### What does this PR do?

plugin library passes around the `PackageInstallOptions`.  If you pass any options, it eventually gets to here
https://github.com/forcedotcom/packaging/blob/b7c470d07cfb0915752c37a84fbde04c534fc12d/src/package/packageInstall.ts#L199

where an undefined `frequency` will become `0`.  It looks like the intent was to have a 5 sec default.  So now both defaults are applied when options are sent BUT freq or timeout aren't included in those options.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2319
[@W-13797305@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001WeCjbYAF/view)