### PR TITLE
Sem/optimize queries 1gp to 2gp conversions

### DIFF
--- a/messages/package_version_create.md
+++ b/messages/package_version_create.md
@@ -194,3 +194,15 @@ The version number is required and was not found in the options or in package js
 # missingConnection
 
 A connection is required.
+
+# IdUnavailableWhenQueued
+
+Request is queued. ID unavailable.
+
+# IdUnavailableWhenInProgress
+
+Request is in progress. ID unavailable.
+
+# IdUnavailableWhenError
+
+ID Unavailable

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -73,6 +73,7 @@ export type PackageVersionCreateRequestResult = {
   CreatedDate: string;
   HasMetadataRemoved: boolean | null;
   CreatedBy: string;
+  ConvertedFromVersionId: string | null;
 };
 
 export const PackageVersionCreateRequestResultInProgressStatuses = Object.values(Package2VersionStatus).filter(
@@ -203,6 +204,7 @@ export type PackageVersionListOptions = {
   verbose?: boolean;
   concise?: boolean;
   isReleased?: boolean;
+  showConversionsOnly?: boolean;
 };
 
 export type PackageVersionUpdateOptions = {
@@ -328,6 +330,7 @@ export type PackageVersionCreateRequestQueryOptions = {
   createdlastdays?: number;
   status?: 'Queued' | 'InProgress' | 'Success' | 'Error';
   id?: string;
+  showConversionsOnly?: boolean;
 };
 
 export type ProfileApiOptions = {

--- a/src/package/packageVersionList.ts
+++ b/src/package/packageVersionList.ts
@@ -36,12 +36,12 @@ const defaultFields = [
   'AncestorId',
   'ValidationSkipped',
   'CreatedById',
+  'ConvertedFromVersionId',
 ];
 
 const verboseFields = [
   'CodeCoverage',
   'HasPassedCodeCoverageCheck',
-  'ConvertedFromVersionId',
   'ReleaseVersion',
   'BuildDurationInSeconds',
   'HasMetadataRemoved',
@@ -129,6 +129,10 @@ export function constructWhere(options?: PackageVersionListOptions): string[] {
 
   if (options?.isReleased) {
     where.push('IsReleased = true');
+  }
+
+  if (options?.showConversionsOnly) {
+    where.push('ConvertedFromVersionId != null');
   }
 
   // exclude deleted

--- a/src/package/packageVersionReport.ts
+++ b/src/package/packageVersionReport.ts
@@ -16,7 +16,7 @@ import { PackageVersionReportResult } from '../interfaces';
 const QUERY =
   'SELECT Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
   'MajorVersion, MinorVersion, PatchVersion, BuildNumber, IsReleased, CodeCoverage, HasPassedCodeCoverageCheck, ' +
-  'Package2.IsOrgDependent, ReleaseVersion, BuildDurationInSeconds, HasMetadataRemoved, CreatedById ' +
+  'Package2.IsOrgDependent, ReleaseVersion, BuildDurationInSeconds, HasMetadataRemoved, CreatedById, ConvertedFromVersionId  ' +
   'FROM Package2Version ' +
   "WHERE Id = '%s' AND IsDeprecated != true " +
   'ORDER BY Package2Id, Branch, MajorVersion, MinorVersion, PatchVersion, BuildNumber';

--- a/test/package/packageConvert.test.ts
+++ b/test/package/packageConvert.test.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { expect } from 'chai';
 import { instantiateContext, MockTestOrgData, restoreContext, stubContext } from '@salesforce/core/lib/testSetup';
-import { Connection, Lifecycle } from '@salesforce/core';
+import { Connection, Lifecycle, Messages } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import {
   convertPackage,
@@ -18,6 +18,9 @@ import {
 } from '../../src/package/packageConvert';
 import { PackageEvents } from '../../src/interfaces';
 import { MetadataResolver } from '../../src/package/packageVersionCreate';
+
+Messages.importMessagesDirectory(__dirname);
+const messages = Messages.loadMessages('@salesforce/packaging', 'package_version_create');
 
 describe('packageConvert', () => {
   const $$ = instantiateContext();
@@ -229,6 +232,7 @@ describe('packageConvert', () => {
 
     const successResponse = {
       Branch: 'main',
+      ConvertedFromVersionId: undefined,
       CreatedBy: undefined,
       CreatedDate: '2022-09-01 00:00',
       Error: [],
@@ -249,6 +253,7 @@ describe('packageConvert', () => {
         message: '',
         packageVersionCreateRequestResult: {
           Branch: undefined,
+          ConvertedFromVersionId: messages.getMessage('IdUnavailableWhenError'),
           CreatedBy: undefined,
           CreatedDate: 'NaN-NaN-NaN NaN:NaN',
           Error: [],

--- a/test/package/packageConvert.test.ts
+++ b/test/package/packageConvert.test.ts
@@ -253,7 +253,7 @@ describe('packageConvert', () => {
         message: '',
         packageVersionCreateRequestResult: {
           Branch: undefined,
-          ConvertedFromVersionId: messages.getMessage('IdUnavailableWhenError'),
+          ConvertedFromVersionId: messages.getMessage('IdUnavailableWhenInProgress'),
           CreatedBy: undefined,
           CreatedDate: 'NaN-NaN-NaN NaN:NaN',
           Error: [],

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -44,6 +44,7 @@ const VERSION_CREATE_RESPONSE_KEYS = [
   'CreatedDate',
   'HasMetadataRemoved',
   'CreatedBy',
+  'ConvertedFromVersionId',
 ];
 
 // version
@@ -356,7 +357,8 @@ describe('Integration tests for @salesforce/packaging library', () => {
           'Error',
           'CreatedDate',
           'HasMetadataRemoved',
-          'CreatedBy'
+          'CreatedBy',
+          'ConvertedFromVersionId'
         );
         expect(res.Id.startsWith('08c')).to.be.true;
         expect(res.Package2Id.startsWith('0Ho')).to.be.true;
@@ -381,7 +383,8 @@ describe('Integration tests for @salesforce/packaging library', () => {
         'Error',
         'CreatedDate',
         'HasMetadataRemoved',
-        'CreatedBy'
+        'CreatedBy',
+        'ConvertedFromVersionId'
       );
       const createdDate = new Date(result[0].CreatedDate);
       const currentDate = new Date();

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -143,6 +143,7 @@ describe('Package Version Create', () => {
     const result = await pvc.createPackageVersion();
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -170,6 +171,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].CalculateCodeCoverage).to.equal(true);
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -195,6 +197,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].CalculateCodeCoverage).to.equal(false);
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -224,6 +227,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].Tag).to.equal('DancingBears');
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -251,6 +255,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].skipancestorcheck).to.equal(undefined);
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -277,6 +282,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].SkipValidation).to.equal(true);
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -304,6 +310,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].SkipValidation).to.equal(false);
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -324,6 +331,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].Branch).to.equal('main');
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -366,6 +374,7 @@ describe('Package Version Create', () => {
 
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -409,6 +418,7 @@ describe('Package Version Create', () => {
 
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -450,6 +460,7 @@ describe('Package Version Create', () => {
 
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -471,6 +482,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].Language).to.equal('en_US');
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -492,6 +504,7 @@ describe('Package Version Create', () => {
     expect(packageCreateStub.firstCall.args[1].Language).to.be.undefined;
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -518,6 +531,7 @@ describe('Package Version Create', () => {
     const result = await pvc.createPackageVersion();
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -662,6 +676,7 @@ describe('Package Version Create', () => {
     expect(validationSpy.callCount).to.equal(1);
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',
@@ -729,6 +744,7 @@ describe('Package Version Create', () => {
     const result = await pvc.createPackageVersion();
     expect(result).to.have.all.keys(
       'Branch',
+      'ConvertedFromVersionId',
       'CreatedBy',
       'CreatedDate',
       'Error',


### PR DESCRIPTION
### What does this PR do?
**CLI improvements for handling 1GP to 2GP conversions**

Developers need tools that facilitate their task of migrating packages from first generation to second generation. For this reason, the following changes are proposed to make it easier for developers to consult and track migration tasks.

**Summary of changes made**

**Command: package:version:list**

Add the `--show-conversions-only` parameter to the `package:version:list` command that filters the output to only show package versions that were created as part of the package conversion operation.
Display the `Converted From Version Id` column when the `package:version:list` command is run under the following scenarios:
with `--show-conversions-only` parameter
with `--verbose parameter` (already works)
or both

**Command: package:version:report**

Add the `Converted From Version Id `field to the output only for versions converted from first-generation packages.

**Command: package:version:create:list**

Add the `--show-conversions-only` parameter to the package:version:create:list command that filters the output to only show package version creation requests that were created as part of the package conversion operation.
Display the `Converted From Version Id` column when the `package:version:create:list` command is run under the following scenarios:
with `--show-conversions-only parameter`

**Command: package:version:create:report**

Add the Converted From Version Id field to the output only for versions converted from first-generation packages.

**To make these changes, changes were made to the following projects:**

https://github.com/forcedotcom/packaging
https://github.com/salesforcecli/plugin-packaging

@W-13054469@