### PR TITLE
fix: show underlying error message for pkgInstall errors

### DIFF
--- a/src/package/packageInstall.ts
+++ b/src/package/packageInstall.ts
@@ -233,6 +233,9 @@ export async function pollStatus(
       // add the original stack to this new error
       error.stack += `\nDUE TO:\n${e.stack}`;
     }
+    if (e.message) {
+      error.actions = (error.actions ?? []).concat([e.message]);
+    }
     throw error;
   }
 }

--- a/src/package/packageInstall.ts
+++ b/src/package/packageInstall.ts
@@ -184,7 +184,9 @@ export async function waitForPublish(
       getLogger().debug(`Error during waitForPublish polling:\n${e.stack}`);
       // append the original stack to this new error
       error.stack += `\nDUE TO:\n${e.stack}`;
-      error.actions = [e.message];
+      if (e.message) {
+        error.actions = (error.actions ?? []).concat([e.message]);
+      }
     }
     throw error;
   }

--- a/src/package/packageInstall.ts
+++ b/src/package/packageInstall.ts
@@ -232,10 +232,11 @@ export async function pollStatus(
     if (error.stack && e instanceof Error && e.stack) {
       // add the original stack to this new error
       error.stack += `\nDUE TO:\n${e.stack}`;
+      if (e.message) {
+        error.actions = (error.actions ?? []).concat([e.message]);
+      }
     }
-    if (e.message) {
-      error.actions = (error.actions ?? []).concat([e.message]);
-    }
+
     throw error;
   }
 }

--- a/src/package/packageInstall.ts
+++ b/src/package/packageInstall.ts
@@ -184,6 +184,7 @@ export async function waitForPublish(
       getLogger().debug(`Error during waitForPublish polling:\n${e.stack}`);
       // append the original stack to this new error
       error.stack += `\nDUE TO:\n${e.stack}`;
+      error.actions = [e.message];
     }
     throw error;
   }


### PR DESCRIPTION
there's a message in the caught error, which isn't making it out into the UI.  This adds the underlying message into the actions 

@W-14095032@
https://github.com/forcedotcom/cli/issues/2434


bug repro: 
create a scrach org, then try to deploy this package to it (the pkg has an install key so this should error out).
`sf package:install --package 04t4p00000281x3AAA --publish-wait 60 --wait 60`

nicest if combined with https://github.com/salesforcecli/sf-plugins-core/pull/407