### PR TITLE
fix: revise error message for package version retrieve command

### DIFF
--- a/messages/package.md
+++ b/messages/package.md
@@ -36,7 +36,7 @@ Can’t retrieve package version metadata. The specified directory must be relat
 
 # unableToAccessMetadataZip
 
-Can’t retrieve package version metadata. Ensure that you’re using API version 59.0 or higher, and that you have the user permissions needed to access fields on the MetadataPackageVersion object.
+The sf package version retrieve command has been removed. This feature isn’t quite ready for prime time, so we’re removing it for now while we make improvements. We’ll let you know after it’s back up.
 
 # errorDownloadingMetadataZip
 

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -341,7 +341,7 @@ describe('Package Version Retrieve', () => {
     } catch (e) {
       const error = e as SfError;
       expect(error.message).to.equal(
-        'Can’t retrieve package version metadata. Ensure that you’re using API version 59.0 or higher, and that you have the user permissions needed to access fields on the MetadataPackageVersion object.'
+        'The sf package version retrieve command has been removed. This feature isn’t quite ready for prime time, so we’re removing it for now while we make improvements. We’ll let you know after it’s back up.'
       );
     }
   });


### PR DESCRIPTION
@W-14221604@
Access to the MetdataPackageVersion.MetadataZip field has been restricted. Updating the error message while we work to get the `package version retrieve` command ready for general consumption.