### PR TITLE
Sm/core6

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@salesforce/core": "^6.1.0",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/schemas": "^1.6.1",
-    "@salesforce/source-deploy-retrieve": "^9.8.5",
+    "@salesforce/source-deploy-retrieve": "^10.0.0",
     "@salesforce/ts-types": "^2.0.9",
     "fast-xml-parser": "^4.3.1",
     "globby": "^11",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@oclif/core": "^2.15.0",
-    "@salesforce/core": "^6.1.0",
+    "@salesforce/core": "^6.1.1",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/schemas": "^1.6.1",
     "@salesforce/source-deploy-retrieve": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@oclif/core": "^2.15.0",
-    "@salesforce/core": "^6.1.1",
+    "@salesforce/core": "^6.1.2",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/schemas": "^1.6.1",
     "@salesforce/source-deploy-retrieve": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@oclif/core": "^2.15.0",
-    "@salesforce/core": "^5.3.14",
+    "@salesforce/core": "^6.1.0",
     "@salesforce/kit": "^3.0.15",
     "@salesforce/schemas": "^1.6.1",
     "@salesforce/source-deploy-retrieve": "^9.8.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "packaging"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "docs",

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -172,8 +172,6 @@ export type PackageDescriptorJson = Partial<NamedPackageDir> &
     features: string[];
     orgPreferences: string[];
     snapshot: string;
-    unpackagedMetadata: NamedPackageDir;
-    seedMetadata: NamedPackageDir;
     apexTestAccess: { permissionSets: string[] | string; permissionSetLicenses: string[] | string };
     permissionSetNames: string[];
     permissionSetLicenseDeveloperNames: string[];

--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -634,12 +634,16 @@ export class PackageVersion {
       }`;
       const build = versionResult.BuildNumber ? `-${versionResult.BuildNumber}` : '';
       const branch = versionResult.Branch ? `-${versionResult.Branch}` : '';
-      // set packageAliases entry '<package>@<major>.<minor>.<patch>-<build>-<branch>: <result.subscriberPackageVersionId>'
-      const packageAliases = this.project.getSfProjectJson().getContents().packageAliases ?? {};
-      if (results.SubscriberPackageVersionId) {
-        packageAliases[`${version}${build}${branch}`] = results.SubscriberPackageVersionId;
-      }
-      this.project.getSfProjectJson().getContents().packageAliases = packageAliases;
+      const originalPackageAliases = this.project.getSfProjectJson().get('packageAliases') ?? {};
+      const updatedPackageAliases = {
+        ...originalPackageAliases,
+        ...(results.SubscriberPackageVersionId
+          ? // set packageAliases entry '<package>@<major>.<minor>.<patch>-<build>-<branch>: <result.subscriberPackageVersionId>'
+            { [`${version}${build}${branch}`]: results.SubscriberPackageVersionId }
+          : {}),
+      };
+
+      this.project.getSfProjectJson().set('packageAliases', updatedPackageAliases);
       await this.project.getSfProjectJson().write();
     }
   }

--- a/src/package/packageVersionRetrieve.ts
+++ b/src/package/packageVersionRetrieve.ts
@@ -201,8 +201,8 @@ async function attemptToUpdateProjectJson(
         );
 
         project.getSfProjectJson().addPackageAlias(alias, writtenId);
-        if (pkgData.ContainerOptions === 'Managed' && !project.getSfProjectJson().getContents().namespace) {
-          project.getSfProjectJson().getContents().namespace = pkgData.NamespacePrefix;
+        if (pkgData.ContainerOptions === 'Managed' && !project.getSfProjectJson().get('namespace')) {
+          project.getSfProjectJson().set('namespace', pkgData.NamespacePrefix);
         }
 
         await project.getSfProjectJson().write();

--- a/test/package/packageCreate.test.ts
+++ b/test/package/packageCreate.test.ts
@@ -173,7 +173,6 @@ describe('packageCreate', () => {
             versionName: 'ver 0.1',
             versionNumber: '0.1.0.NEXT',
           });
-          // @ts-expect-error requires https://github.com/forcedotcom/sfdx-core/pull/989
           proj.getSfProjectJson().set('packageDirectories', packageDirectories);
         });
         const packageDirEntry = createPackageDirEntry(project, {

--- a/test/package/packageCreate.test.ts
+++ b/test/package/packageCreate.test.ts
@@ -173,6 +173,7 @@ describe('packageCreate', () => {
             versionName: 'ver 0.1',
             versionNumber: '0.1.0.NEXT',
           });
+          // @ts-expect-error requires https://github.com/forcedotcom/sfdx-core/pull/989
           proj.getSfProjectJson().set('packageDirectories', packageDirectories);
         });
         const packageDirEntry = createPackageDirEntry(project, {

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -601,6 +601,7 @@ describe('ancestry tests', () => {
     pkg.package = pkgName;
     pkg.versionNumber = sortedVersions[0].toString();
     pkg.versionName = 'v1';
+    // @ts-expect-error requires https://github.com/forcedotcom/sfdx-core/pull/989
     pjson.set('packageDirectories', [pkg]);
     aliases = Object.fromEntries([
       ...pvRecords.map((pv, index) => [

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -601,7 +601,6 @@ describe('ancestry tests', () => {
     pkg.package = pkgName;
     pkg.versionNumber = sortedVersions[0].toString();
     pkg.versionName = 'v1';
-    // @ts-expect-error requires https://github.com/forcedotcom/sfdx-core/pull/989
     pjson.set('packageDirectories', [pkg]);
     aliases = Object.fromEntries([
       ...pvRecords.map((pv, index) => [

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -611,7 +611,7 @@ describe('ancestry tests', () => {
     ]) as { [alias: string]: string };
     pjson.set('packageAliases', aliases);
     pjson.set('namespace', pvRecords[0].Package2.NamespacePrefix);
-    pjson.writeSync();
+    await pjson.write();
   });
 
   after(async () => {

--- a/test/package/packageVersion.test.ts
+++ b/test/package/packageVersion.test.ts
@@ -31,7 +31,6 @@ describe('Package Version', () => {
         versionName: 'ver 0.1',
         versionNumber: '0.1.0.NEXT',
         default: false,
-        name: 'pkg',
       },
       {
         path: 'force-app',

--- a/test/package/packageVersion.test.ts
+++ b/test/package/packageVersion.test.ts
@@ -24,39 +24,39 @@ describe('Package Version', () => {
   beforeEach(async () => {
     $$.inProject(true);
     project = SfProject.getInstance();
-    await project.getSfProjectJson().write({
-      packageDirectories: [
-        {
-          path: 'pkg',
-          package: 'dep',
-          versionName: 'ver 0.1',
-          versionNumber: '0.1.0.NEXT',
-          default: false,
-          name: 'pkg',
-        },
-        {
-          path: 'force-app',
-          package: 'TEST',
-          versionName: 'ver 0.1',
-          versionNumber: '0.1.0.NEXT',
-          default: true,
-          ancestorId: 'TEST2',
-          unpackagedMetadata: {
-            path: 'unpackaged',
-          },
-          dependencies: [
-            {
-              package: 'DEP@0.1.0-1',
-            },
-          ],
-        },
-      ],
-      packageAliases: {
-        dupPkg1: packageId,
-        dupPkg2: packageId,
-        uniquePkg: uniquePackageId,
+    project.getSfProjectJson().set('packageDirectories', [
+      {
+        path: 'pkg',
+        package: 'dep',
+        versionName: 'ver 0.1',
+        versionNumber: '0.1.0.NEXT',
+        default: false,
+        name: 'pkg',
       },
+      {
+        path: 'force-app',
+        package: 'TEST',
+        versionName: 'ver 0.1',
+        versionNumber: '0.1.0.NEXT',
+        default: true,
+        ancestorId: 'TEST2',
+        unpackagedMetadata: {
+          path: 'unpackaged',
+        },
+        dependencies: [
+          {
+            package: 'DEP@0.1.0-1',
+          },
+        ],
+      },
+    ]);
+    project.getSfProjectJson().set('packageAliases', {
+      dupPkg1: packageId,
+      dupPkg2: packageId,
+      uniquePkg: uniquePackageId,
     });
+    await project.getSfProjectJson().write();
+
     await fs.promises.mkdir(path.join(project.getPath(), 'force-app'));
     stubContext($$);
     await $$.stubAuths(testOrg);

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -14,6 +14,8 @@ import {
   PackageVersionCreate,
   packageXmlStringToPackageXmlJson,
   packageXmlJsonToXmlString,
+  validateAncestorId,
+  validateVersionNumber,
 } from '../../src/package/packageVersionCreate';
 import * as PVCStubs from '../../src/package/packageVersionCreate';
 import { PackagingSObjects } from '../../src/interfaces';
@@ -54,7 +56,6 @@ describe('Package Version Create', () => {
         versionName: 'ver 0.1',
         versionNumber: '0.1.0.NEXT',
         default: false,
-        name: 'pkg',
       },
       {
         path: 'force-app',
@@ -366,7 +367,6 @@ describe('Package Version Create', () => {
       config.packageDirectories[1].dependencies[0].versionNumber = '0.1.0.1';
     }
 
-    // @ts-expect-error : requires https://github.com/forcedotcom/sfdx-core/pull/989
     project.getSfProjectJson().set('packageDirectories', config.packageDirectories);
     await project.getSfProjectJson().write();
 
@@ -412,7 +412,6 @@ describe('Package Version Create', () => {
       config.packageDirectories[1].dependencies[0].versionNumber = '0.1.0.1';
       config.packageDirectories[1].dependencies[0].branch = 'dev';
     }
-    // @ts-expect-error : requires https://github.com/forcedotcom/sfdx-core/pull/989
     project.getSfProjectJson().set('packageDirectories', config.packageDirectories);
     await project.getSfProjectJson().write();
 
@@ -458,7 +457,6 @@ describe('Package Version Create', () => {
       config.packageDirectories[1].dependencies[0].versionNumber = '0.1.0.1';
       config.packageDirectories[1].dependencies[0].branch = '';
     }
-    // @ts-expect-error : requires https://github.com/forcedotcom/sfdx-core/pull/989
     project.getSfProjectJson().set('packageDirectories', config.packageDirectories);
     await project.getSfProjectJson().write();
 
@@ -717,7 +715,6 @@ describe('Package Version Create', () => {
         versionName: 'ver 0.1',
         versionNumber: '0.1.0.NEXT',
         default: false,
-        name: 'pkg',
         unpackagedMetadata: {
           path: 'unpackaged-pkg',
         },
@@ -793,7 +790,6 @@ describe('Package Version Create', () => {
         versionName: 'ver 0.1',
         versionNumber: '0.1.0.NEXT',
         default: false,
-        name: 'pkg',
         unpackagedMetadata: {
           path: 'unpackaged-pkg',
         },
@@ -884,10 +880,6 @@ describe('Package Version Create', () => {
   });
 
   describe('validateAncestorId', () => {
-    let pvc: PackageVersionCreate;
-    beforeEach(() => {
-      pvc = new PackageVersionCreate({ connection, project, packageId });
-    });
     it('should throw if the explicitUseNoAncestor is true and highestReleasedVersion is not undefined', () => {
       const ancestorId = 'ancestorId';
       const highestReleasedVersion = {
@@ -901,7 +893,7 @@ describe('Package Version Create', () => {
       const skipAncestorCheck = false;
       const origSpecifiedAncestor = 'orgAncestorId';
       expect(() =>
-        pvc['validateAncestorId'](
+        validateAncestorId(
           ancestorId,
           highestReleasedVersion,
           explicitUseNoAncestor,
@@ -924,7 +916,7 @@ describe('Package Version Create', () => {
       const skipAncestorCheck = false;
       const origSpecifiedAncestor = 'orgAncestorId';
       expect(() =>
-        pvc['validateAncestorId'](
+        validateAncestorId(
           ancestorId,
           highestReleasedVersion,
           explicitUseNoAncestor,
@@ -943,7 +935,7 @@ describe('Package Version Create', () => {
       const isPatch = false;
       const skipAncestorCheck = false;
       const origSpecifiedAncestor = 'orgAncestorId';
-      const result = pvc['validateAncestorId'](
+      const result = validateAncestorId(
         ancestorId,
         highestReleasedVersion,
         explicitUseNoAncestor,
@@ -960,7 +952,7 @@ describe('Package Version Create', () => {
       const isPatch = true;
       const skipAncestorCheck = true;
       const origSpecifiedAncestor = 'orgAncestorId';
-      const result = pvc['validateAncestorId'](
+      const result = validateAncestorId(
         ancestorId,
         highestReleasedVersion,
         explicitUseNoAncestor,
@@ -972,17 +964,13 @@ describe('Package Version Create', () => {
     });
   });
   describe('validateVersionNumber', () => {
-    let pvc: PackageVersionCreate;
-    beforeEach(() => {
-      pvc = new PackageVersionCreate({ connection, project, packageId });
-    });
     it('should return version number as valid', () => {
-      const versionNumber = pvc['validateVersionNumber']('1.2.3.NEXT', 'NEXT', 'LATEST');
+      const versionNumber = validateVersionNumber('1.2.3.NEXT', 'NEXT', 'LATEST');
       expect(versionNumber).to.be.equal('1.2.3.NEXT');
     });
     it('should throw error if version number is invalid', () => {
       expect(() => {
-        pvc['validateVersionNumber']('1.2.3.NEXT', 'foo', 'bar');
+        validateVersionNumber('1.2.3.NEXT', 'foo', 'bar');
       }).to.throw(
         Error,
         /The provided VersionNumber '1.2.3.NEXT' is invalid. Provide an integer value or use the keyword/
@@ -990,7 +978,7 @@ describe('Package Version Create', () => {
     });
     it('should throw error if build2 is undefined', () => {
       expect(() => {
-        pvc['validateVersionNumber']('1.2.3.NEXT', 'foo', undefined);
+        validateVersionNumber('1.2.3.NEXT', 'foo', undefined);
       }).to.throw(
         Error,
         /The provided VersionNumber '1.2.3.NEXT' is invalid. Provide an integer value or use the keyword/

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -107,14 +107,13 @@ describe('Package Version Retrieve', () => {
   beforeEach(async () => {
     $$.inProject(true);
     project = SfProject.getInstance();
-    await project.getSfProjectJson().write({
-      packageDirectories: [
-        {
-          path: 'force-app',
-          default: true,
-        },
-      ],
-    });
+    project.getSfProjectJson().set('packageDirectories', [
+      {
+        path: 'force-app',
+        default: true,
+      },
+    ]);
+    await project.getSfProjectJson().write();
     stubContext($$);
     await $$.stubAuths(testOrg);
     connection = await testOrg.getConnection();
@@ -167,6 +166,7 @@ describe('Package Version Retrieve', () => {
   afterEach(async () => {
     restoreContext($$);
     $$.restore();
+    project.getSfProjectJson().unsetAll(['namespace', 'packageAliases']);
     const pathToClean = path.join(project.getPath(), destinationFolder);
     if (fs.existsSync(pathToClean)) {
       await fs.promises.rm(pathToClean, { recursive: true });
@@ -190,15 +190,14 @@ describe('Package Version Retrieve', () => {
   });
 
   it('should not change the namespace in sfdx-project.json if it is already set', async () => {
-    await project.getSfProjectJson().write({
-      packageDirectories: [
-        {
-          path: 'force-app',
-          default: true,
-        },
-      ],
-      namespace: 'existingNS',
-    });
+    project.getSfProjectJson().set('packageDirectories', [
+      {
+        path: 'force-app',
+        default: true,
+      },
+    ]);
+    project.getSfProjectJson().set('namespace', 'existingNS');
+    await project.getSfProjectJson().write();
 
     const result = await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);
     expect(result.converted).to.not.be.undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,12 +675,12 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.1.tgz#7d1c071e1e509ca9d2d8a6e48ac7447dd67a534d"
   integrity sha512-eVy947ZMxCJReKJdgfddUIsBIbPTa/i8RwQGwxq4/ss38H5sLOAeSTaun9V7HpJ1hkpDznWKfgzYvjsst9K6ig==
 
-"@salesforce/source-deploy-retrieve@^9.8.5":
-  version "9.8.5"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-9.8.5.tgz#0cdcdd94894fd30c4923fbdcbd3f35f33bef7ecc"
-  integrity sha512-6mkyKLz00M0cB/44w93/k9N2EEJeO7oUkCGPzfcxGOABdoqwQUZ15FetIuSKqfAWSbV5wFrw6TxGJ5Du8HrO6A==
+"@salesforce/source-deploy-retrieve@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-10.0.0.tgz#572642bb3bfb1d7421afb201d7dc7de0a43271d9"
+  integrity sha512-6d9F1jTkD4fXYd5i+xowTey//Vns3ZlOhNNNqkQv7UlfZA8ttoxY5aYQAsAv8A/q/IcMx3UoeIKJZxUE2zNgPQ==
   dependencies:
-    "@salesforce/core" "^5.3.17"
+    "@salesforce/core" "^6.1.0"
     "@salesforce/kit" "^3.0.15"
     "@salesforce/ts-types" "^2.0.9"
     fast-levenshtein "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,10 +597,34 @@
     semver "^7.5.4"
     ts-retry-promise "^0.7.1"
 
-"@salesforce/core@^6.1.0", "@salesforce/core@^6.1.1":
+"@salesforce/core@^6.1.0":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.1.1.tgz#ef55ca6a1f16304ebe3826c6974a30c489772f79"
   integrity sha512-hmvgF6/y04i/lP4Qspg6tmmApdJ6QR2vs9PNsl08rUwwePvHtI0fzjqEFZEMOMYSyKdFrSZYY6U3CAO1CLyTKg==
+  dependencies:
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/schemas" "^1.6.1"
+    "@salesforce/ts-types" "^2.0.9"
+    "@types/semver" "^7.5.4"
+    ajv "^8.12.0"
+    change-case "^4.1.2"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.28"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^8.16.1"
+    pino-abstract-transport "^1.1.0"
+    pino-pretty "^10.2.3"
+    proper-lockfile "^4.1.2"
+    semver "^7.5.4"
+    ts-retry-promise "^0.7.1"
+
+"@salesforce/core@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.1.2.tgz#604c0cd3e3858e2f51c37b1a0904825015a07765"
+  integrity sha512-h1sGWUfAMVtBvh+wXlSA+e2aJAJ/DnkUD+GLgRje6qUsgxKRNJcoKBCNZgjwAf+xAqJ5IprUZ+arTkU5ME86Mw==
   dependencies:
     "@salesforce/kit" "^3.0.15"
     "@salesforce/schemas" "^1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -597,10 +597,10 @@
     semver "^7.5.4"
     ts-retry-promise "^0.7.1"
 
-"@salesforce/core@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.1.0.tgz#8ed2775366d8b659efd27717bfb35fa0f223ba05"
-  integrity sha512-KyExbJAGnL87ExbiLkWGDGDGXXJSvANrdFsaEdSV3kTJNeCCcKw8GCtKlULMfNJieSB4VpfxNhKKVRht1SoMdg==
+"@salesforce/core@^6.1.0", "@salesforce/core@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.1.1.tgz#ef55ca6a1f16304ebe3826c6974a30c489772f79"
+  integrity sha512-hmvgF6/y04i/lP4Qspg6tmmApdJ6QR2vs9PNsl08rUwwePvHtI0fzjqEFZEMOMYSyKdFrSZYY6U3CAO1CLyTKg==
   dependencies:
     "@salesforce/kit" "^3.0.15"
     "@salesforce/schemas" "^1.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,7 +573,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.7.1"
 
-"@salesforce/core@^5.3.10", "@salesforce/core@^5.3.14", "@salesforce/core@^5.3.17":
+"@salesforce/core@^5.3.10", "@salesforce/core@^5.3.17":
   version "5.3.20"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-5.3.20.tgz#4e934d4551bb70423cb1c4115615bc41cffca41e"
   integrity sha512-y+O6O2c8OYFDrAy2qsG+pAcNxoyL14nmBXcBRRcYA7Huj8ikK+aLJK84PuVAYdQz+hNwImQF+69IWtDkpK4Irg==
@@ -592,6 +592,30 @@
     jszip "3.10.1"
     pino "^8.16.0"
     pino-abstract-transport "^1.0.0"
+    pino-pretty "^10.2.3"
+    proper-lockfile "^4.1.2"
+    semver "^7.5.4"
+    ts-retry-promise "^0.7.1"
+
+"@salesforce/core@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.1.0.tgz#8ed2775366d8b659efd27717bfb35fa0f223ba05"
+  integrity sha512-KyExbJAGnL87ExbiLkWGDGDGXXJSvANrdFsaEdSV3kTJNeCCcKw8GCtKlULMfNJieSB4VpfxNhKKVRht1SoMdg==
+  dependencies:
+    "@salesforce/kit" "^3.0.15"
+    "@salesforce/schemas" "^1.6.1"
+    "@salesforce/ts-types" "^2.0.9"
+    "@types/semver" "^7.5.4"
+    ajv "^8.12.0"
+    change-case "^4.1.2"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.28"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^8.16.1"
+    pino-abstract-transport "^1.1.0"
     pino-pretty "^10.2.3"
     proper-lockfile "^4.1.2"
     semver "^7.5.4"
@@ -4491,7 +4515,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pino-abstract-transport@^1.0.0, pino-abstract-transport@v1.1.0:
+pino-abstract-transport@^1.0.0, pino-abstract-transport@^1.1.0, pino-abstract-transport@v1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
   integrity sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==
@@ -4524,7 +4548,7 @@ pino-std-serializers@^6.0.0:
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz#d9a9b5f2b9a402486a5fc4db0a737570a860aab3"
   integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
 
-pino@^8.16.0:
+pino@^8.16.0, pino@^8.16.1:
   version "8.16.1"
   resolved "https://registry.yarnpkg.com/pino/-/pino-8.16.1.tgz#dcaf82764b1a27f24101317cdd6453e96290f1d9"
   integrity sha512-3bKsVhBmgPjGV9pyn4fO/8RtoVDR8ssW1ev819FsRXlRNgW8gR/9Kx+gCK4UPWd4JjrRDLWpzd/pb1AyWm3MGA==


### PR DESCRIPTION
bump to core6 and current SDR
use new typed SfProject
avoid SfProject.write(contents) which is gone for CRDT reasons.  This mostly happened in tests.
Change places that relied on side-effects from mutating the result of getContents().  Explicitly set props instead.

fix types for PackageDescriptorJson
@W-14085765@