### PR TITLE
fix: limit package version list test to last 5 days

### DIFF
--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -260,7 +260,7 @@ describe('Integration tests for @salesforce/packaging library', () => {
     });
 
     it('package version should be in results of static Package#listVersions', async () => {
-      const pkgVersions = await Package.listVersions(devHubOrg.getConnection(), project);
+      const pkgVersions = await Package.listVersions(devHubOrg.getConnection(), project, { createdLastDays: 5 });
       expect(pkgVersions.some((pvlr) => pvlr.SubscriberPackageVersionId === subscriberPkgVersionId)).to.be.true;
     });
 


### PR DESCRIPTION
The test was running into 10k query limit, so limiting the list results to the last 5 days should fix things.

[skip-validate-pr]