### PR TITLE
fix: add id on version create timeout

### DIFF
--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -151,6 +151,9 @@ export class PackageVersion {
     if (createResult.Id) {
       return PackageVersion.pollCreateStatus(createResult.Id, options.connection, options.project, polling).catch(
         (err: Error) => {
+          if (err.name === 'PollingClientTimeout') {
+            err.message += ` Run 'sf package version create report -i ${createResult.Id}' to check the status.`;
+          }
           // TODO
           // until package2 is GA, wrap perm-based errors w/ 'contact sfdc' action (REMOVE once package2 is GA'd)
           throw applyErrorAction(massageErrorMessage(err));

--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection, Lifecycle, Messages, PollingClient, SfProject, StatusResult } from '@salesforce/core';
+import { Connection, Lifecycle, Messages, PollingClient, SfError, SfProject, StatusResult } from '@salesforce/core';
 import { Duration, env } from '@salesforce/kit';
 import { Optional } from '@salesforce/ts-types';
 import {
@@ -150,8 +150,9 @@ export class PackageVersion {
 
     if (createResult.Id) {
       return PackageVersion.pollCreateStatus(createResult.Id, options.connection, options.project, polling).catch(
-        (err: Error) => {
+        (err: SfError) => {
           if (err.name === 'PollingClientTimeout') {
+            err.setData({ VersionCreateRequestId: createResult.Id });
             err.message += ` Run 'sf package version create report -i ${createResult.Id}' to check the status.`;
           }
           // TODO


### PR DESCRIPTION
Adds the request id to the error message when the `package version create` command times out. This Id can be used with `sf package version create report -i THE_ID` to look up the status of the version creation.

Added info to the `error.message` and also added the id as `VersionCreateRequestId` using `setData` on `SfError`. The key for this was derived from [these docs](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_unlocked_pkg_create_pkg_ver.htm)

Sidenote: The `applyErrorAction` ([source](https://github.com/forcedotcom/packaging/blob/6abaa79d0a9bb744ec0a3675a4e02dbee0f78600/src/utils/packageUtils.ts#L112)) does not appear to be working as expected. The `action` property is being stripped off when the error is thrown.

QA: 
- Pull branch
- `yarn compile`
- `yarn link`
- cd to `plugin-packaging`
- `yarn link @salesforce/packaging`
- From an sf project with a Package run `../plugin-packaging/bin/run.js package version create --package Dreamhouse --wait 1 -x --code-coverage --version-description "Test version" --version-number 59.0.0.NEXT --json`
  - Note the `--wait 1`, this should time out before finishing
- Note the error message includes `Run 'sf package version create report -i 08cKY00000001wQYAQ' to check the status."`
- Note that the json includes the ID under `data.VersionCreateRequestId` 

Fixes https://github.com/forcedotcom/cli/issues/2605
[@W-14670120@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14670120)