### PR TITLE
fix: set string replace env var before convert

### DIFF
--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -1010,12 +1010,24 @@ export class MetadataResolver {
     packageName: string | undefined
   ): Promise<ConvertResult> {
     const converter = new MetadataConverter();
-    return converter.convert(componentSet, 'metadata', {
-      type: 'directory',
-      outputDirectory,
-      packageName,
-      genUniqueDir: false,
-    });
+    // Set the SF_APPLY_REPLACEMENTS_ON_CONVERT env var so that
+    // string replacements happen automatically.
+    const replaceOnConvert = process.env.SF_APPLY_REPLACEMENTS_ON_CONVERT;
+    try {
+      env.setBoolean('SF_APPLY_REPLACEMENTS_ON_CONVERT', true);
+      return await converter.convert(componentSet, 'metadata', {
+        type: 'directory',
+        outputDirectory,
+        packageName,
+        genUniqueDir: false,
+      });
+    } finally {
+      if (replaceOnConvert === undefined) {
+        env.unset('SF_APPLY_REPLACEMENTS_ON_CONVERT');
+      } else {
+        env.setBoolean('SF_APPLY_REPLACEMENTS_ON_CONVERT', replaceOnConvert.toLowerCase() === 'true');
+      }
+    }
   }
 }
 

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs';
 import { instantiateContext, MockTestOrgData, restoreContext, stubContext } from '@salesforce/core/lib/testSetup';
 import { assert, expect } from 'chai';
 import { Connection, Logger, SfProject } from '@salesforce/core';
+import { env } from '@salesforce/kit';
 import {
   MetadataResolver,
   PackageVersionCreate,
@@ -140,9 +141,15 @@ describe('Package Version Create', () => {
     pjsonXmlConversionStub = $$.SANDBOX.stub(PVCStubs, 'packageXmlStringToPackageXmlJson').returns({});
     const pvc = new PackageVersionCreate({ connection, project, packageId });
 
+    // pvc.convertMetadata() is called, so ensure SF_APPLY_REPLACEMENTS_ON_CONVERT is set
+    // for the convert
+    const envSpy = $$.SANDBOX.spy(env, 'setBoolean').withArgs('SF_APPLY_REPLACEMENTS_ON_CONVERT', true);
+
     try {
       await pvc.createPackageVersion();
+      assert(false, 'should have thrown an error');
     } catch (e) {
+      expect(envSpy.calledOnce).to.equal(true);
       assert(e instanceof Error);
       expect(e.message).to.equal('No matching source was found within the package root directory: force-app');
     }


### PR DESCRIPTION
Sets `SF_APPLY_REPLACEMENTS_ON_CONVERT=true` before converting packaged metadata so that strings are replaced automatically without the need for setting this env var explicitly.  String replacement happens automatically during a deploy, so this matches the expected behavior.  After conversion, the env var is set back to the original state.

@W-14914086@