### PR TITLE
fix: allow increased query fetch limits

### DIFF
--- a/src/package/package.ts
+++ b/src/package/package.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { Connection, Messages, SfError, SfProject } from '@salesforce/core';
+import { env } from '@salesforce/kit';
 import {
   ConvertPackageOptions,
   PackageCreateOptions,
@@ -118,12 +119,13 @@ export class Package {
    * @param connection
    */
   public static async list(connection: Connection): Promise<PackagingSObjects.Package2[]> {
+    const maxFetch = env.getNumber('SF_ORG_MAX_QUERY_LIMIT') ?? 10_000;
     return (
       await connection.tooling.query<PackagingSObjects.Package2>(
         `select ${this.getPackage2Fields(connection).toString()} from Package2 ORDER BY NamespacePrefix, Name`,
         {
           autoFetch: true,
-          maxFetch: 10_000,
+          maxFetch,
         }
       )
     )?.records;

--- a/src/package/packageVersionList.ts
+++ b/src/package/packageVersionList.ts
@@ -6,6 +6,7 @@
  */
 
 import { Connection, Logger, Messages } from '@salesforce/core';
+import { env } from '@salesforce/kit';
 import { QueryResult, Schema } from 'jsforce';
 import { isNumber } from '@salesforce/ts-types';
 import { BY_LABEL, validateId } from '../utils/packageUtils';
@@ -63,10 +64,12 @@ export async function listPackageVersions(
   connection: Connection,
   options?: PackageVersionListOptions
 ): Promise<QueryResult<PackageVersionListResult>> {
+  const maxFetch = env.getNumber('SF_ORG_MAX_QUERY_LIMIT') ?? 10_000;
   return connection.autoFetchQuery<PackageVersionListResult & Schema>(
     constructQuery(Number(connection.version), options),
     {
       tooling: true,
+      maxFetch,
     }
   );
 }


### PR DESCRIPTION
Updated the code to fetch 10,000 records max by default.  To set it higher than that use the `SF_ORG_MAX_QUERY_LIMIT` env var.

@W-13047283@