### PR TITLE
feat: add PS/PSL for package metadata options to sfdx-project.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   ],
   "dependencies": {
     "@oclif/core": "^3",
-    "@salesforce/core": "^6.5.1",
+    "@salesforce/core": "^6.7.6",
     "@salesforce/kit": "^3.0.15",
-    "@salesforce/schemas": "^1.6.1",
+    "@salesforce/schemas": "^1.7.0",
     "@salesforce/source-deploy-retrieve": "^10.3.1",
     "@salesforce/ts-types": "^2.0.9",
     "fast-xml-parser": "^4.3.4",

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -174,9 +174,12 @@ export type PackageDescriptorJson = Partial<NamedPackageDir> &
     features: string[];
     orgPreferences: string[];
     snapshot: string;
+    packageMetadataAccess: { permissionSets: string[] | string; permissionSetLicenses: string[] | string };
     apexTestAccess: { permissionSets: string[] | string; permissionSetLicenses: string[] | string };
     permissionSetNames: string[];
     permissionSetLicenseDeveloperNames: string[];
+    packageMetadataPermissionSetNames: string[];
+    packageMetadataPermissionSetLicenseNames: string[];
     branch: string;
     subscriberPackageVersionId: string;
     packageId: string;

--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -374,7 +374,7 @@ export class PackageVersionCreate {
       packageDescriptorJson = copyDescriptorProperties(packageDescriptorJson, definitionFileJson);
     }
 
-    this.resolveApexTestPermissions(packageDescriptorJson);
+    this.resolveBuildUserPermissions(packageDescriptorJson);
 
     // All dependencies for the packaging dir should be resolved to an 04t id to be passed to the server.
     // (see _retrieveSubscriberPackageVersionId for details)
@@ -573,7 +573,7 @@ export class PackageVersionCreate {
     await zipDir(packageVersBlobDirectory, packageVersBlobZipFile);
   }
 
-  private resolveApexTestPermissions(packageDescriptorJson: PackageDescriptorJson): void {
+  private resolveBuildUserPermissions(packageDescriptorJson: PackageDescriptorJson): void {
     // Process permissionSet and permissionSetLicenses that should be enabled when running Apex tests
     // This only applies if code coverage is enabled
     if (this.options.codecoverage) {
@@ -595,7 +595,25 @@ export class PackageVersionCreate {
       }
     }
 
+    // Process permissionSet and permissionsetLicenses that should be enabled for the package metadata deploy
+    if (packageDescriptorJson.packageMetadataAccess?.permissionSets) {
+      let permSets = packageDescriptorJson.packageMetadataAccess.permissionSets;
+      if (!Array.isArray(permSets)) {
+        permSets = permSets.split(',');
+      }
+      packageDescriptorJson.packageMetadataPermissionSetNames = permSets.map((s) => s.trim());
+    }
+
+    if (packageDescriptorJson.packageMetadataAccess?.permissionSetLicenses) {
+      let permissionSetLicenses = packageDescriptorJson.packageMetadataAccess.permissionSetLicenses;
+      if (!Array.isArray(permissionSetLicenses)) {
+        permissionSetLicenses = permissionSetLicenses.split(',');
+      }
+      packageDescriptorJson.packageMetadataPermissionSetLicenseNames = permissionSetLicenses.map((s) => s.trim());
+    }
+
     delete packageDescriptorJson.apexTestAccess;
+    delete packageDescriptorJson.packageMetadataAccess;
   }
 
   // eslint-disable-next-line complexity

--- a/yarn.lock
+++ b/yarn.lock
@@ -637,6 +637,29 @@
     semver "^7.5.4"
     ts-retry-promise "^0.7.1"
 
+"@salesforce/core@^6.7.6":
+  version "6.7.6"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-6.7.6.tgz#6a73c6a4e615ce837be5b5c142cfc63a6c8db3bd"
+  integrity sha512-0ZZ1GgUQTwTs8/xa+hmZd+wwKXkK8MNcI2Kn20HmHShsweA2Jp3Yaxx0+EbRPqhSBARXso+TADSnsOjlZvQ3tg==
+  dependencies:
+    "@salesforce/kit" "^3.1.0"
+    "@salesforce/schemas" "^1.7.0"
+    "@salesforce/ts-types" "^2.0.9"
+    ajv "^8.12.0"
+    change-case "^4.1.2"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsforce "^2.0.0-beta.29"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^8.19.0"
+    pino-abstract-transport "^1.1.0"
+    pino-pretty "^10.3.1"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.0"
+    ts-retry-promise "^0.7.1"
+
 "@salesforce/dev-config@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-4.1.0.tgz#e529576466d074e7a5f1441236510fef123da01e"
@@ -682,6 +705,14 @@
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"
 
+"@salesforce/kit@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.0.tgz#aa42533084c676e865f0f9c1907a16fb6f74dee7"
+  integrity sha512-X2d9O/U2wdQBXIrtVqQdMwo872Cv+qkYFzF0W+AQKG/LEe9cngnOzUVDYNkGD9tq3jcl+oenHXYuVDpkMhxTwA==
+  dependencies:
+    "@salesforce/ts-types" "^2.0.9"
+    tslib "^2.6.2"
+
 "@salesforce/prettier-config@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.3.tgz#ba648d4886bb38adabe073dbea0b3a91b3753bb0"
@@ -691,6 +722,11 @@
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.6.1.tgz#7d1c071e1e509ca9d2d8a6e48ac7447dd67a534d"
   integrity sha512-eVy947ZMxCJReKJdgfddUIsBIbPTa/i8RwQGwxq4/ss38H5sLOAeSTaun9V7HpJ1hkpDznWKfgzYvjsst9K6ig==
+
+"@salesforce/schemas@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.7.0.tgz#b7e0af3ee414ae7160bce351c0184d77ccb98fe3"
+  integrity sha512-Z0PiCEV55khm0PG+DsnRYCjaDmacNe3HDmsoSm/CSyYvJJm+D5vvkHKN9/PKD/gaRe8XAU836yfamIYFblLINw==
 
 "@salesforce/source-deploy-retrieve@^10.3.1":
   version "10.3.1"
@@ -4728,6 +4764,23 @@ pino@^8.16.0, pino@^8.17.2:
     sonic-boom "^3.7.0"
     thread-stream "^2.0.0"
 
+pino@^8.19.0:
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-8.19.0.tgz#ccc15ef736f103ec02cfbead0912bc436dc92ce4"
+  integrity sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport v1.1.0
+    pino-std-serializers "^6.0.0"
+    process-warning "^3.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^3.7.0"
+    thread-stream "^2.0.0"
+
 pkg-dir@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -5163,6 +5216,13 @@ semver@^7.3.4, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
[@W-14842023@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001iQVLhYAO/view)

Add support for additional properties in sfdx-project.json to allow specifying permission sets and permission set licenses to the build org user for package metadata deploy during the package version creation process.