### PR TITLE
@W-14742535@ Fix: definition-file keys case sensitivity

### DIFF
--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -510,7 +510,10 @@ export function copyDescriptorProperties(
     packageDescriptorJsonCopy,
     Object.fromEntries(
       ['country', 'edition', 'language', 'features', 'orgPreferences', 'snapshot', 'release', 'sourceOrg'].map(
-        (prop) => [[prop], definitionFileJsonCopy[prop]]
+        (prop) => {
+          const matchCase = Object.keys(definitionFileJsonCopy).find((key) => key.toLowerCase() === prop.toLowerCase());
+          return [[prop], matchCase ? definitionFileJsonCopy[matchCase] : undefined];
+        }
       )
     )
   ) as PackageDescriptorJson;

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -498,7 +498,14 @@ export function copyDir(src: string, dest: string): void {
     return entry.isDirectory() ? copyDir(srcPath, destPath) : fs.copyFileSync(srcPath, destPath);
   });
 }
-
+/**
+ * Parse and copy properties from both of these arguments into a new object
+ *
+ * @param packageDescriptorJson
+ * @param definitionFileJson
+ * @returns the resulting object with specific properties
+ * overridden from definition file based on case-insensitive matches.
+ */
 export function copyDescriptorProperties(
   packageDescriptorJson: PackageDescriptorJson,
   definitionFileJson: ScratchOrgInfo

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -1053,40 +1053,39 @@ describe('Package Version Create', () => {
       const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
       expect(package2DescriptorJson).to.have.string('snapshot');
     });
-  });
 
-  it("should create package version from the snapShot (camel-case or any-case) property in definition file's", async () => {
-    const scratchOrgDefFileContent = '{ "snapShot": "SnapScratchOrg2" }';
-    const scratchOrgDefFileName = 'project-scratch-def.json';
-    $$.SANDBOX.stub(fs.promises, 'readFile').withArgs(scratchOrgDefFileName).resolves(scratchOrgDefFileContent);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    $$.SANDBOX.stub(MetadataResolver.prototype, 'generateMDFolderForArtifact' as any).resolves();
-    $$.SANDBOX.stub(fs, 'existsSync').returns(true);
-    const writeFileSpy = $$.SANDBOX.spy(fs.promises, 'writeFile');
+    it("should create package version from the snapShot (camel-case or any-case) property in definition file's", async () => {
+      const scratchOrgDefFileContent = '{ "snapShot": "SnapScratchOrg2" }';
+      const scratchOrgDefFileName = 'project-scratch-def.json';
+      $$.SANDBOX.stub(fs.promises, 'readFile').withArgs(scratchOrgDefFileName).resolves(scratchOrgDefFileContent);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $$.SANDBOX.stub(MetadataResolver.prototype, 'generateMDFolderForArtifact' as any).resolves();
+      $$.SANDBOX.stub(fs, 'existsSync').returns(true);
+      const writeFileSpy = $$.SANDBOX.spy(fs.promises, 'writeFile');
 
-    const pvc = new PackageVersionCreate({ connection, project, definitionfile: scratchOrgDefFileName, packageId });
-    const result = await pvc.createPackageVersion();
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+      const pvc = new PackageVersionCreate({ connection, project, definitionfile: scratchOrgDefFileName, packageId });
+      const result = await pvc.createPackageVersion();
+      expect(result).to.have.all.keys(
+        'Branch',
+        'ConvertedFromVersionId',
+        'CreatedBy',
+        'CreatedDate',
+        'Error',
+        'HasMetadataRemoved',
+        'HasPassedCodeCoverageCheck',
+        'Id',
+        'Package2Id',
+        'Package2Name',
+        'Package2VersionId',
+        'Status',
+        'SubscriberPackageVersionId',
+        'Tag'
+      );
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
-    console.log(package2DescriptorJson); // eslint-disable-line no-console
-    expect(package2DescriptorJson).to.have.string('snapshot');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
+      expect(package2DescriptorJson).to.have.string('snapshot');
+    });
   });
 });
 

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -1019,6 +1019,75 @@ describe('Package Version Create', () => {
       );
     });
   });
+
+  describe('handle case sensitivity for project-scratch-def.json keys', () => {
+    it('should create package version from the snapshot (lower-case) property in definition file', async () => {
+      const scratchOrgDefFileContent = '{ "snapshot": "SnapScratchOrg" }';
+      const scratchOrgDefFileName = 'project-scratch-def.json';
+      $$.SANDBOX.stub(fs.promises, 'readFile').withArgs(scratchOrgDefFileName).resolves(scratchOrgDefFileContent);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      $$.SANDBOX.stub(MetadataResolver.prototype, 'generateMDFolderForArtifact' as any).resolves();
+      $$.SANDBOX.stub(fs, 'existsSync').returns(true);
+      const writeFileSpy = $$.SANDBOX.spy(fs.promises, 'writeFile');
+
+      const pvc = new PackageVersionCreate({ connection, project, definitionfile: scratchOrgDefFileName, packageId });
+      const result = await pvc.createPackageVersion();
+      expect(result).to.have.all.keys(
+        'Branch',
+        'ConvertedFromVersionId',
+        'CreatedBy',
+        'CreatedDate',
+        'Error',
+        'HasMetadataRemoved',
+        'HasPassedCodeCoverageCheck',
+        'Id',
+        'Package2Id',
+        'Package2Name',
+        'Package2VersionId',
+        'Status',
+        'SubscriberPackageVersionId',
+        'Tag'
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
+      expect(package2DescriptorJson).to.have.string('snapshot');
+    });
+  });
+
+  it("should create package version from the snapShot (camel-case or any-case) property in definition file's", async () => {
+    const scratchOrgDefFileContent = '{ "snapShot": "SnapScratchOrg2" }';
+    const scratchOrgDefFileName = 'project-scratch-def.json';
+    $$.SANDBOX.stub(fs.promises, 'readFile').withArgs(scratchOrgDefFileName).resolves(scratchOrgDefFileContent);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    $$.SANDBOX.stub(MetadataResolver.prototype, 'generateMDFolderForArtifact' as any).resolves();
+    $$.SANDBOX.stub(fs, 'existsSync').returns(true);
+    const writeFileSpy = $$.SANDBOX.spy(fs.promises, 'writeFile');
+
+    const pvc = new PackageVersionCreate({ connection, project, definitionfile: scratchOrgDefFileName, packageId });
+    const result = await pvc.createPackageVersion();
+    expect(result).to.have.all.keys(
+      'Branch',
+      'ConvertedFromVersionId',
+      'CreatedBy',
+      'CreatedDate',
+      'Error',
+      'HasMetadataRemoved',
+      'HasPassedCodeCoverageCheck',
+      'Id',
+      'Package2Id',
+      'Package2Name',
+      'Package2VersionId',
+      'Status',
+      'SubscriberPackageVersionId',
+      'Tag'
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
+    console.log(package2DescriptorJson); // eslint-disable-line no-console
+    expect(package2DescriptorJson).to.have.string('snapshot');
+  });
 });
 
 describe('PackageXml read/write', () => {


### PR DESCRIPTION
The creation of the scratch org (build org) during the “package version create” command results in the org created without snapshot, because the snapshot property is null, even though the snapshot is specified in the scratch org definition file as "snapShot". 

While the scratch org is successfully created using the ‘snapShot’ property (uppercase ‘S’) with the “scratch org create” command. We should match this behavior.

- Actual Result

Scratch org (build org) created without the properties of Snapshot. For ex: Profiles that are created on the snapshotted org are missing in the build org.

- Expected Result

Scratch org (build org) should be created with the properties of Snapshot. The "package version create" command should not fail due to a missing custom profile that was from the snapshotted org.

@W-14742535@