### PR TITLE
fix: move some verbose fields to default fields

### DIFF
--- a/src/package/packageVersionList.ts
+++ b/src/package/packageVersionList.ts
@@ -37,15 +37,12 @@ const defaultFields = [
   'ValidationSkipped',
   'CreatedById',
   'ConvertedFromVersionId',
-];
-
-const verboseFields = [
-  'CodeCoverage',
-  'HasPassedCodeCoverageCheck',
   'ReleaseVersion',
   'BuildDurationInSeconds',
   'HasMetadataRemoved',
 ];
+
+const verboseFields = ['CodeCoverage', 'HasPassedCodeCoverageCheck'];
 
 const verbose57Fields = ['Language'];
 

--- a/src/package/packageVersionReport.ts
+++ b/src/package/packageVersionReport.ts
@@ -14,16 +14,16 @@ import * as pkgUtils from '../utils/packageUtils';
 import { PackageVersionReportResult } from '../interfaces';
 
 const QUERY =
-  'SELECT Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
+  'SELECT Id, Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
   'MajorVersion, MinorVersion, PatchVersion, BuildNumber, IsReleased, CodeCoverage, HasPassedCodeCoverageCheck, ' +
   'Package2.IsOrgDependent, ReleaseVersion, BuildDurationInSeconds, HasMetadataRemoved, CreatedById, ConvertedFromVersionId  ' +
   'FROM Package2Version ' +
   "WHERE Id = '%s' AND IsDeprecated != true " +
   'ORDER BY Package2Id, Branch, MajorVersion, MinorVersion, PatchVersion, BuildNumber';
 
-// verbose adds: Id, ConvertedFromVersionId, SubscriberPackageVersion.Dependencies
+// verbose adds: ConvertedFromVersionId, SubscriberPackageVersion.Dependencies
 const QUERY_VERBOSE =
-  'SELECT Id, Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
+  'SELECT Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
   'MajorVersion, MinorVersion, PatchVersion, BuildNumber, IsReleased, CodeCoverage, HasPassedCodeCoverageCheck, ConvertedFromVersionId, ' +
   'Package2.IsOrgDependent, ReleaseVersion, BuildDurationInSeconds, HasMetadataRemoved, SubscriberPackageVersion.Dependencies, ' +
   'CreatedById, CodeCoveragePercentages ' +


### PR DESCRIPTION
Move the non-CodeCoverage fields from the verbose query to the default query so that JSON responses are more accurate.

@W-15398724@