### PR TITLE
fix: move verbose field to default fields

### DIFF
--- a/src/package/packageVersionList.ts
+++ b/src/package/packageVersionList.ts
@@ -71,7 +71,7 @@ export async function listPackageVersions(
   return connection.autoFetchQuery<PackageVersionListResult & Schema>(query, { tooling: true });
 }
 
-function constructQuery(connectionVersion: number, options?: PackageVersionListOptions): string {
+export function constructQuery(connectionVersion: number, options?: PackageVersionListOptions): string {
   // construct custom WHERE clause, if applicable
   const where = constructWhere(options);
 

--- a/src/package/packageVersionList.ts
+++ b/src/package/packageVersionList.ts
@@ -37,15 +37,12 @@ const defaultFields = [
   'ValidationSkipped',
   'CreatedById',
   'ConvertedFromVersionId',
-];
-
-const verboseFields = [
-  'CodeCoverage',
-  'HasPassedCodeCoverageCheck',
   'ReleaseVersion',
   'BuildDurationInSeconds',
   'HasMetadataRemoved',
 ];
+
+const verboseFields = ['CodeCoverage', 'HasPassedCodeCoverageCheck'];
 
 const verbose57Fields = ['Language'];
 

--- a/src/package/packageVersionReport.ts
+++ b/src/package/packageVersionReport.ts
@@ -14,16 +14,16 @@ import * as pkgUtils from '../utils/packageUtils';
 import { PackageVersionReportResult } from '../interfaces';
 
 const QUERY =
-  'SELECT Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
+  'SELECT Id, Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
   'MajorVersion, MinorVersion, PatchVersion, BuildNumber, IsReleased, CodeCoverage, HasPassedCodeCoverageCheck, ' +
   'Package2.IsOrgDependent, ReleaseVersion, BuildDurationInSeconds, HasMetadataRemoved, CreatedById, ConvertedFromVersionId  ' +
   'FROM Package2Version ' +
   "WHERE Id = '%s' AND IsDeprecated != true " +
   'ORDER BY Package2Id, Branch, MajorVersion, MinorVersion, PatchVersion, BuildNumber';
 
-// verbose adds: Id, ConvertedFromVersionId, SubscriberPackageVersion.Dependencies
+// verbose adds: ConvertedFromVersionId, SubscriberPackageVersion.Dependencies
 const QUERY_VERBOSE =
-  'SELECT Id, Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
+  'SELECT Package2Id, SubscriberPackageVersionId, Name, Description, Tag, Branch, AncestorId, ValidationSkipped, ' +
   'MajorVersion, MinorVersion, PatchVersion, BuildNumber, IsReleased, CodeCoverage, HasPassedCodeCoverageCheck, ConvertedFromVersionId, ' +
   'Package2.IsOrgDependent, ReleaseVersion, BuildDurationInSeconds, HasMetadataRemoved, SubscriberPackageVersion.Dependencies, ' +
   'CreatedById, CodeCoveragePercentages ' +

--- a/test/package/packageVersionList.test.ts
+++ b/test/package/packageVersionList.test.ts
@@ -12,6 +12,7 @@ import {
   constructWhere,
   DEFAULT_ORDER_BY_FIELDS,
   validateDays,
+  constructQuery,
 } from '../../src/package/packageVersionList';
 
 describe('package version list', () => {
@@ -75,6 +76,50 @@ describe('package version list', () => {
       expect(where).to.include('LastModifiedDate = LAST_N_DAYS:2');
     });
   });
+
+  describe('_constructQuery', () => {
+    it('should include verbose fields', async () => {
+      const options = {
+        packages: ['0Ho3h000000xxxxCAG'],
+        createdLastDays: 1,
+        modifiedLastDays: 2,
+        isReleased: true,
+        verbose: true,
+      };
+      const constQuery = constructQuery(50, options);
+      expect(constQuery).to.include('CodeCoverage');
+      expect(constQuery).to.include('HasPassedCodeCoverageCheck');
+      expect(constQuery).to.not.include('Language');
+    });
+
+    it('should include verbose fields with langage', async () => {
+      const options = {
+        packages: ['0Ho3h000000xxxxCAG'],
+        createdLastDays: 1,
+        modifiedLastDays: 2,
+        isReleased: true,
+        verbose: true,
+      };
+      const constQuery = constructQuery(59, options);
+      expect(constQuery).to.include('CodeCoverage');
+      expect(constQuery).to.include('HasPassedCodeCoverageCheck');
+      expect(constQuery).to.include('Language');
+    });
+
+    it('should not include verbose fields', async () => {
+      const options = {
+        packages: ['0Ho3h000000xxxxCAG'],
+        createdLastDays: 1,
+        modifiedLastDays: 2,
+        isReleased: true,
+      };
+      const constQuery = constructQuery(59, options);
+      expect(constQuery).to.not.include('CodeCoverage');
+      expect(constQuery).to.not.include('HasPassedCodeCoverageCheck');
+      expect(constQuery).to.not.include('Language');
+    });
+  });
+
   describe('_assembleQueryParts', () => {
     it('should return the proper query', () => {
       const assembly = assembleQueryParts('select foo,bar,baz from foobarbaz', ['foo=1', "bar='2'"], 'foo,bar,baz');


### PR DESCRIPTION
Move the non-CodeCoverage fields from the verbose query to the default query so that JSON responses are more accurate.

@W-15398724@