### PR TITLE
fix: better error handling when installing packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.2.0",
-    "@salesforce/core": "^7.3.8",
+    "@salesforce/core": "^7.3.9",
     "@salesforce/kit": "^3.1.1",
     "@salesforce/schemas": "^1.9.0",
     "@salesforce/source-deploy-retrieve": "^11.4.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@jsforce/jsforce-node": "^3.2.0",
     "@salesforce/core": "^7.3.9",
-    "@salesforce/kit": "^3.1.1",
+    "@salesforce/kit": "^3.1.2",
     "@salesforce/schemas": "^1.9.0",
     "@salesforce/source-deploy-retrieve": "^11.4.4",
     "@salesforce/ts-types": "^2.0.9",

--- a/src/package/packageInstall.ts
+++ b/src/package/packageInstall.ts
@@ -187,6 +187,14 @@ export async function waitForPublish(
     getLogger().debug(`Polling timeout (min): ${pollingOptions.timeout.minutes}`);
     await pollingClient.subscribe();
   } catch (e) {
+    // For installation key problems throw that error.
+    if (e instanceof Error && e.name.includes('INSTALL_KEY')) {
+      throw SfError.create({
+        name: e.name,
+        message: e.message,
+        cause: e,
+      });
+    }
     // if polling timed out
     const error = installMsgs.createError('subscriberPackageVersionNotPublished');
     if (queryResult?.records[0]) {

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -368,15 +368,16 @@ describe('Integration tests for @salesforce/packaging library', () => {
     it('will list all of the created package versions (status = Success)', async () => {
       const result = await PackageVersion.getPackageVersionCreateRequests(devHubOrg.getConnection(), {
         status: 'Success',
+        createdlastdays: 3,
       });
       result.map((res) => {
         // we should've filtered to only successful package versions1
         expect(res.Status).to.equal('Success');
         expect(res).to.have.all.keys(VERSION_CREATE_RESPONSE_KEYS);
-        expect(res.Id.startsWith('08c')).to.be.true;
-        expect(res.Package2Id.startsWith('0Ho')).to.be.true;
-        expect(res.Package2VersionId.startsWith('05i')).to.be.true;
-        expect(res.SubscriberPackageVersionId?.startsWith('04t')).to.be.true;
+        expect(res.Id.startsWith('08c'), 'res.Id').to.be.true;
+        expect(res.Package2Id.startsWith('0Ho'), 'res.Package2Id').to.be.true;
+        expect(res.Package2VersionId.startsWith('05i'), 'res.Package2VersionId').to.be.true;
+        expect(res.SubscriberPackageVersionId?.startsWith('04t'), 'res.SubscriberPackageVersionId').to.be.true;
       });
     });
 

--- a/test/package/subscriberPackageVersion.test.ts
+++ b/test/package/subscriberPackageVersion.test.ts
@@ -148,7 +148,7 @@ describe('subscriberPackageVersion', () => {
 
     const id = '04txxxxxxxxxxxxxxy';
     const subscriberPackageVersion = new SubscriberPackageVersion({ connection, aliasOrId: id, password });
-    queryStub = $$.SANDBOX.stub(connection, 'singleRecordQuery').throws('No record found');
+    queryStub = $$.SANDBOX.stub(connection, 'singleRecordQuery').throws(Error('Request failed'));
     expect(queryStub.called).to.be.false;
     try {
       await subscriberPackageVersion.getPackageType();
@@ -159,6 +159,24 @@ describe('subscriberPackageVersion', () => {
         /The subscriber package version 04txxxxxxxxxxxxxxy is invalid, no subscriber package version record found/,
         error.message
       );
+      expect(queryStub.called).to.be.true;
+    }
+  });
+  it('should propagate the same error from the SPV query', async () => {
+    connection = await testOrg.getConnection();
+
+    const id = '04txxxxxxxxxxxxxxy';
+    const subscriberPackageVersion = new SubscriberPackageVersion({ connection, aliasOrId: id, password });
+    queryStub = $$.SANDBOX.stub(connection, 'singleRecordQuery').throws(
+      Error('Invalid InstallationKey for SubscriberPackageVersion')
+    );
+    expect(queryStub.called).to.be.false;
+    try {
+      await subscriberPackageVersion.getPackageType();
+      expect.fail('should have thrown "Invalid InstallationKey for SubscriberPackageVersion"');
+    } catch (e) {
+      const error = e as Error;
+      expect(error.message).to.equal('Invalid InstallationKey for SubscriberPackageVersion');
       expect(queryStub.called).to.be.true;
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,6 +630,14 @@
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"
 
+"@salesforce/kit@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.2.tgz#270741c54c70969df19ef17f8979b4ef1fa664b2"
+  integrity sha512-si+ddvZDgx9q5czxAANuK5xhz3pv+KGspQy1wyia/7HDPKadA0QZkLTzUnO1Ju4Mux32CNHEb2y9lw9jj+eVTA==
+  dependencies:
+    "@salesforce/ts-types" "^2.0.9"
+    tslib "^2.6.2"
+
 "@salesforce/prettier-config@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.3.tgz#ba648d4886bb38adabe073dbea0b3a91b3753bb0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,14 +562,14 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.0"
 
-"@salesforce/core@^7.3.1", "@salesforce/core@^7.3.5", "@salesforce/core@^7.3.8":
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.8.tgz#8a646b5321f08c0fb4d22e2fa8b1d60b3a20df9b"
-  integrity sha512-VWhXHfjwjtC3pJWYp8wt5/fnNQ5tK61ovMG5eteXzVD2oFd7og1f6YjwuAzoYIZK7kYWWv7KJfGtCsPs7Zw+Ww==
+"@salesforce/core@^7.3.1", "@salesforce/core@^7.3.5", "@salesforce/core@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.9.tgz#8abe2b3e2393989d11e92b7a6b96043fc9d5b9c8"
+  integrity sha512-eJqDiA5b7wU50Ee/xjmGzSnHrNVJ8S77B7enfX30gm7gxU3i3M3QeBdiV6XAOPLSIL96DseofP6Tv6c+rljlKA==
   dependencies:
     "@jsforce/jsforce-node" "^3.2.0"
     "@salesforce/kit" "^3.1.1"
-    "@salesforce/schemas" "^1.7.0"
+    "@salesforce/schemas" "^1.9.0"
     "@salesforce/ts-types" "^2.0.9"
     ajv "^8.13.0"
     change-case "^4.1.2"
@@ -635,7 +635,7 @@
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.3.tgz#ba648d4886bb38adabe073dbea0b3a91b3753bb0"
   integrity sha512-hYOhoPTCSYMDYn+U1rlEk16PoBeAJPkrdg4/UtAzupM1mRRJOwEPMG1d7U8DxJFKuXW3DMEYWr2MwAIBDaHmFg==
 
-"@salesforce/schemas@^1.7.0", "@salesforce/schemas@^1.9.0":
+"@salesforce/schemas@^1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
@@ -5074,16 +5074,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5142,14 +5133,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5622,7 +5606,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5635,15 +5619,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Changes error handling to either re-throw the original message, or throw a new error using the old error as context.

GH Issue: https://github.com/forcedotcom/cli/issues/2882
@W-15832085@