### PR TITLE
refactor: type consolidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@jsforce/jsforce-node": "^3.2.0",
     "@salesforce/core": "7.3.12-qa.1",
-    "@salesforce/kit": "^3.1.2",
+    "@salesforce/kit": "^3.1.6",
     "@salesforce/schemas": "^1.9.0",
     "@salesforce/source-deploy-retrieve": "^11.6.6",
     "@salesforce/ts-types": "^2.0.9",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.2.0",
-    "@salesforce/core": "7.3.12-qa.0",
+    "@salesforce/core": "7.3.12-qa.1",
     "@salesforce/kit": "^3.1.2",
     "@salesforce/schemas": "^1.9.0",
     "@salesforce/source-deploy-retrieve": "^11.6.6",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.2.0",
-    "@salesforce/core": "^7.3.9",
+    "@salesforce/core": "^7.3.12",
     "@salesforce/kit": "^3.1.2",
     "@salesforce/schemas": "^1.9.0",
-    "@salesforce/source-deploy-retrieve": "^11.6.4",
+    "@salesforce/source-deploy-retrieve": "^11.6.6",
     "@salesforce/ts-types": "^2.0.9",
     "@salesforce/types": "^1.1.0",
     "fast-xml-parser": "^4.4.0",
@@ -59,7 +59,6 @@
   "devDependencies": {
     "@salesforce/cli-plugins-testkit": "^5.3.8",
     "@salesforce/dev-scripts": "^9.1.2",
-    "@salesforce/ts-sinon": "^1.4.19",
     "@types/globby": "^9.1.0",
     "@types/jszip": "^3.4.1",
     "eslint-plugin-sf-plugin": "^1.18.5",

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "object-treeify": "^2"
   },
   "devDependencies": {
-    "@salesforce/cli-plugins-testkit": "^5.3.8",
-    "@salesforce/dev-scripts": "^9.1.2",
+    "@salesforce/cli-plugins-testkit": "^5.3.15",
+    "@salesforce/dev-scripts": "^10.2.0",
     "@types/globby": "^9.1.0",
     "@types/jszip": "^3.4.1",
-    "eslint-plugin-sf-plugin": "^1.18.5",
+    "eslint-plugin-sf-plugin": "^1.18.8",
     "shelljs": "0.8.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@salesforce/core": "8.0.1",
     "@salesforce/kit": "^3.1.6",
     "@salesforce/schemas": "^1.9.0",
-    "@salesforce/source-deploy-retrieve": "^11.6.6",
+    "@salesforce/source-deploy-retrieve": "^12.0.1",
     "@salesforce/ts-types": "^2.0.9",
     "@salesforce/types": "^1.1.0",
     "fast-xml-parser": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.2.0",
-    "@salesforce/core": "^7.3.12",
+    "@salesforce/core": "7.3.12-qa.0",
     "@salesforce/kit": "^3.1.2",
     "@salesforce/schemas": "^1.9.0",
     "@salesforce/source-deploy-retrieve": "^11.6.6",

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -295,11 +295,12 @@ export type SubscriberPackageVersionOptions = {
 };
 
 export type ConvertPackageOptions = {
-  installationKey: string;
-  definitionfile: string;
+  installationKey?: string;
+  definitionfile?: string;
+  /** @deprecated stop using it*/
   installationKeyBypass: boolean;
   wait: Duration;
-  buildInstance: string;
+  buildInstance?: string;
   frequency?: Duration;
   seedMetadata?: string;
 };

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -6,13 +6,13 @@
  */
 
 import { Duration } from '@salesforce/kit';
-import { Connection, SfProject } from '@salesforce/core';
+import { Connection } from '@salesforce/core';
+import { NamedPackagingDir, SfProject } from '@salesforce/core/project';
 import type { SaveResult } from '@jsforce/jsforce-node';
 import { Attributes } from 'graphology-types';
 import { Optional } from '@salesforce/ts-types';
 import { ConvertResult } from '@salesforce/source-deploy-retrieve';
 import type { Package } from '@salesforce/types/metadata';
-import { NamedPackagingDir } from '@salesforce/core/project';
 import { PackageProfileApi } from '../package/packageProfileApi';
 import { PackageAncestryNode } from '../package/packageAncestry';
 import { PackagingSObjects } from './packagingSObjects';

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -6,12 +6,13 @@
  */
 
 import { Duration } from '@salesforce/kit';
-import { Connection, NamedPackageDir, SfProject } from '@salesforce/core';
+import { Connection, SfProject } from '@salesforce/core';
 import type { SaveResult } from '@jsforce/jsforce-node';
 import { Attributes } from 'graphology-types';
 import { Optional } from '@salesforce/ts-types';
 import { ConvertResult } from '@salesforce/source-deploy-retrieve';
 import type { Package } from '@salesforce/types/metadata';
+import { NamedPackagingDir } from '@salesforce/core/project';
 import { PackageProfileApi } from '../package/packageProfileApi';
 import { PackageAncestryNode } from '../package/packageAncestry';
 import { PackagingSObjects } from './packagingSObjects';
@@ -170,7 +171,7 @@ export type PackageCreateOptions = {
   path: string;
 };
 
-export type PackageDescriptorJson = Partial<NamedPackageDir> &
+export type PackageDescriptorJson = Partial<NamedPackagingDir> &
   Partial<{
     id: string;
     features: string[];

--- a/src/package/packageConvert.ts
+++ b/src/package/packageConvert.ts
@@ -21,7 +21,7 @@ import {
   ScratchOrgSettingsGenerator,
 } from '@salesforce/core';
 import { camelCaseToTitleCase, Duration, env } from '@salesforce/kit';
-import { Many } from '@salesforce/ts-types';
+import { Many, ensureString } from '@salesforce/ts-types';
 import * as pkgUtils from '../utils/packageUtils';
 import { copyDescriptorProperties, generatePackageAliasEntry, uniqid } from '../utils/packageUtils';
 import {
@@ -113,7 +113,10 @@ export async function convertPackage(
 
   const packageId = await findOrCreatePackage2(pkg, connection, project);
 
-  const apiVersion = project?.getSfProjectJson()?.get('sourceApiVersion') as string;
+  const apiVersion = ensureString(
+    project?.getSfProjectJson()?.get('sourceApiVersion'),
+    'sfProjectJson is missing sourceApiVersion'
+  );
 
   const request = await createPackageVersionCreateRequest(
     {

--- a/src/package/packageConvert.ts
+++ b/src/package/packageConvert.ts
@@ -46,6 +46,7 @@ const getLogger = (): Logger => {
   }
   return logger;
 };
+const POLL_INTERVAL_SECONDS = 30;
 
 export async function findOrCreatePackage2(
   seedPackage: string,
@@ -107,7 +108,7 @@ export async function convertPackage(
   let maxRetries = 0;
   const branch = 'main';
   if (options.wait) {
-    maxRetries = (60 / pkgUtils.POLL_INTERVAL_SECONDS) * options.wait.minutes;
+    maxRetries = (60 / POLL_INTERVAL_SECONDS) * options.wait.minutes;
   }
 
   const packageId = await findOrCreatePackage2(pkg, connection, project);
@@ -142,7 +143,7 @@ export async function convertPackage(
       branch,
       project,
       connection,
-      options.frequency ?? Duration.seconds(pkgUtils.POLL_INTERVAL_SECONDS)
+      options.frequency ?? Duration.seconds(POLL_INTERVAL_SECONDS)
     );
   } else {
     results = await byId(packageId, connection);

--- a/src/package/packageCreate.ts
+++ b/src/package/packageCreate.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Connection, PackageDir, SfError, SfProject } from '@salesforce/core';
+import { Connection, SfError, SfProject } from '@salesforce/core';
 import { env } from '@salesforce/kit';
-import { PackagePackageDir } from '@salesforce/schemas';
+import { PackagePackageDir, PackageDir } from '@salesforce/schemas';
 import * as pkgUtils from '../utils/packageUtils';
 import { applyErrorAction, massageErrorMessage } from '../utils/packageUtils';
 import { PackageCreateOptions, PackagingSObjects } from '../interfaces';

--- a/src/package/packageDelete.ts
+++ b/src/package/packageDelete.ts
@@ -18,10 +18,7 @@ export async function deletePackage(
   const packageId = project.getPackageIdFromAlias(idOrAlias) ?? idOrAlias;
   validateId(BY_LABEL.PACKAGE_ID, packageId);
 
-  const request = {} as { Id: string; IsDeprecated: boolean };
-  request.Id = packageId;
-  const isUndelete = undelete;
-  request.IsDeprecated = !isUndelete;
+  const request = { Id: packageId, IsDeprecated: !undelete };
 
   const updateResult = await connection.tooling.update('Package2', request).catch((err) => {
     if (err instanceof Error) {

--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -7,7 +7,6 @@
 
 import { Connection, Lifecycle, Messages, PollingClient, SfError, SfProject, StatusResult } from '@salesforce/core';
 import { Duration, env } from '@salesforce/kit';
-import { Optional } from '@salesforce/ts-types';
 import {
   PackageSaveResult,
   PackageType,
@@ -120,7 +119,7 @@ export class PackageVersion {
   private readonly connection: Connection;
 
   private data?: Package2Version;
-  private packageType: Optional<PackageType>;
+  private packageType?: PackageType;
   private id: string;
 
   public constructor(private options: PackageVersionOptions) {

--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -330,7 +330,7 @@ export class PackageVersionCreate {
     const mdOptions: MDFolderForArtifactOptions = {
       deploydir: packageVersMetadataFolder,
       sourceDir: sourceBaseDir,
-      sourceApiVersion: (this.project?.getSfProjectJson()?.get('sourceApiVersion') as string) ?? undefined,
+      sourceApiVersion: this.project?.getSfProjectJson()?.get('sourceApiVersion'),
     };
 
     await fs.promises.mkdir(packageVersBlobDirectory, { recursive: true });

--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -14,7 +14,6 @@ import {
   Logger,
   Messages,
   NamedPackageDir,
-  PackageDir,
   ScratchOrgInfo,
   SfdcUrl,
   SfProject,
@@ -27,10 +26,11 @@ import {
   ConvertResult,
   MetadataConverter,
 } from '@salesforce/source-deploy-retrieve';
-import { PackageDirDependency } from '@salesforce/core/project';
+import { PackageDirDependency, isNamedPackagingDirectory, isPackagingDirectory } from '@salesforce/core/project';
 import { ensureArray, env } from '@salesforce/kit';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
 import { isString } from '@salesforce/ts-types';
+import { PackagePackageDir } from '@salesforce/schemas';
 import * as pkgUtils from '../utils/packageUtils';
 import {
   BY_LABEL,
@@ -525,6 +525,7 @@ export class PackageVersionCreate {
       // don't package the profiles from any un-packagedMetadata dir in the project
       profileExcludeDirs = this.project
         .getPackageDirectories()
+        .filter(isNamedPackagingDirectory)
         .map((packageDir) => packageDir.unpackagedMetadata?.path)
         .filter(isString);
 
@@ -649,7 +650,9 @@ export class PackageVersionCreate {
         if (!packageName) throw messages.createError('errorMissingPackage', [this.options.packageId]);
       }
       packageObject = this.project.findPackage(
-        (namedPackageDir) => namedPackageDir.package === packageName || namedPackageDir.name === packageName
+        (namedPackageDir) =>
+          (isPackagingDirectory(namedPackageDir) && namedPackageDir.package === packageName) ||
+          namedPackageDir.name === packageName
       );
     } else {
       // We'll either have a package ID or alias, or a directory path
@@ -657,8 +660,9 @@ export class PackageVersionCreate {
         throw messages.createError('errorMissingPackagePath', [JSON.stringify(this.options)]);
       }
       packageObject = this.project.getPackageFromPath(this.options.path);
+      if (!packageObject || !isPackagingDirectory(packageObject))
+        throw messages.createError('errorCouldNotFindPackageUsingPath', [this.options.path]);
       packageName = packageObject?.package;
-      if (!packageName) throw messages.createError('errorCouldNotFindPackageUsingPath', [this.options.path]);
     }
 
     if (!packageObject) {
@@ -711,9 +715,11 @@ export class PackageVersionCreate {
     return (await byId(createResult.id, this.connection))[0];
   }
 
-  private async getPackageDirFromId(pkg: string): Promise<PackageDir | undefined> {
+  private async getPackageDirFromId(pkg: string): Promise<PackagePackageDir | undefined> {
     if (pkg.startsWith('0Ho')) {
-      const dir = (await this.project.getSfProjectJson().getPackageDirectories()).filter((p) => p.package === pkg);
+      const dir = (await this.project.getSfProjectJson().getPackageDirectories())
+        .filter(isPackagingDirectory)
+        .filter((p) => p.package === pkg);
       if (dir.length === 1) {
         return dir[0];
       }

--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -26,11 +26,11 @@ import {
   ConvertResult,
   MetadataConverter,
 } from '@salesforce/source-deploy-retrieve';
-import { PackageDirDependency, isNamedPackagingDirectory, isPackagingDirectory } from '@salesforce/core/project';
+import { isNamedPackagingDirectory, isPackagingDirectory } from '@salesforce/core/project';
 import { ensureArray, env } from '@salesforce/kit';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
 import { isString } from '@salesforce/ts-types';
-import { PackagePackageDir } from '@salesforce/schemas';
+import { PackagePackageDir, PackageDirDependency } from '@salesforce/schemas';
 import * as pkgUtils from '../utils/packageUtils';
 import {
   BY_LABEL,

--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -651,8 +651,8 @@ export class PackageVersionCreate {
       }
       packageObject = this.project.findPackage(
         (namedPackageDir) =>
-          (isPackagingDirectory(namedPackageDir) && namedPackageDir.package === packageName) ||
-          namedPackageDir.name === packageName
+          isPackagingDirectory(namedPackageDir) &&
+          (namedPackageDir.package === packageName || namedPackageDir.name === packageName)
       );
     } else {
       // We'll either have a package ID or alias, or a directory path

--- a/src/package/packageVersionRetrieve.ts
+++ b/src/package/packageVersionRetrieve.ts
@@ -72,11 +72,10 @@ export async function retrievePackageVersionMetadata(
 
   // 2GP packages declare their dependencies in dependency-ids.json within the outer zip.
   if (tree.exists('dependency-ids.json')) {
-    type DependencyIds = {
+    const f = await tree.readFile('dependency-ids.json');
+    const idsObj = JSON.parse(f.toString()) as {
       ids: string[];
     };
-    const f = await tree.readFile('dependency-ids.json');
-    const idsObj: DependencyIds = JSON.parse(f.toString()) as DependencyIds;
     if (idsObj?.ids) {
       dependencies = idsObj.ids;
     }

--- a/src/package/packageVersionRetrieve.ts
+++ b/src/package/packageVersionRetrieve.ts
@@ -6,9 +6,10 @@
  */
 import path from 'node:path';
 import fs from 'node:fs';
-import { Connection, Logger, Messages, NamedPackageDir, PackageDirDependency, SfProject } from '@salesforce/core';
+import { Connection, Logger, Messages, SfProject } from '@salesforce/core';
 import { ComponentSet, MetadataConverter, ZipTreeContainer } from '@salesforce/source-deploy-retrieve';
 import { env } from '@salesforce/kit';
+import { PackageDir } from '@salesforce/schemas';
 import {
   PackagingSObjects,
   PackageVersionMetadataDownloadOptions,
@@ -21,14 +22,6 @@ import { PackageVersion } from './packageVersion';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/packaging', 'package');
-
-let logger: Logger;
-const getLogger = (): Logger => {
-  if (!logger) {
-    logger = Logger.childFromRoot('packageVersionRetrieve');
-  }
-  return logger;
-};
 
 /**
  * Download the metadata files for a previously published package version, convert them to source format, and put them into a new project folder within the sfdx project.
@@ -81,7 +74,7 @@ export async function retrievePackageVersionMetadata(
   if (tree.exists('dependency-ids.json')) {
     type DependencyIds = {
       ids: string[];
-    }
+    };
     const f = await tree.readFile('dependency-ids.json');
     const idsObj: DependencyIds = JSON.parse(f.toString()) as DependencyIds;
     if (idsObj?.ids) {
@@ -132,8 +125,9 @@ async function attemptToUpdateProjectJson(
   dependencyIds: string[],
   destinationFolder: string
 ): Promise<void> {
+  const logger = Logger.childFromRoot('packageVersionRetrieve');
   if (env.getBoolean('SF_PROJECT_AUTOUPDATE_DISABLE_FOR_PACKAGE_VERSION_RETRIEVE')) {
-    getLogger().info(
+    logger.info(
       'Skipping sfdx-project.json updates because SF_PROJECT_AUTOUPDATE_DISABLE_FOR_PACKAGE_VERSION_RETRIEVE is set'
     );
     return;
@@ -144,7 +138,7 @@ async function attemptToUpdateProjectJson(
       .retrieve(packageId)) as PackagingSObjects.MetadataPackage;
 
     if (packageInfo.PackageCategory !== 'Package2') {
-      getLogger().info(
+      logger.info(
         `Skipping sfdx-project.json updates because ${packageId} is not a 2GP package. It has a PackageCategory of '${packageInfo.PackageCategory}'`
       );
       return;
@@ -154,10 +148,9 @@ async function attemptToUpdateProjectJson(
       whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
     };
 
-    const versions = await PackageVersion.queryPackage2Version(connection, queryOptions);
+    const [version] = await PackageVersion.queryPackage2Version(connection, queryOptions);
 
-    if (versions.length && versions[0]) {
-      const version = versions[0];
+    if (version) {
       const pkg = new Package({
         packageAliasOrId: version.Package2Id,
         project,
@@ -176,17 +169,13 @@ async function attemptToUpdateProjectJson(
           errorNotificationUsername: pkgData.PackageErrorUsername,
         });
 
-        const dependencies: PackageDirDependency[] = dependencyIds.map(
-          (dep) => ({ package: dep } as PackageDirDependency)
-        );
-
-        const namedDir = {
+        const namedDir: PackageDir = {
           ...dirEntry,
           versionNumber: '<set version number>',
           versionName: '<set version name>',
           ancestorVersion: '<set ancestor version>',
-          dependencies,
-        } as NamedPackageDir;
+          dependencies: dependencyIds.map((dep) => ({ package: dep })),
+        };
 
         project.getSfProjectJson().addPackageDirectory(namedDir);
 
@@ -207,18 +196,18 @@ async function attemptToUpdateProjectJson(
 
         await project.getSfProjectJson().write();
       } else {
-        getLogger().warn(
+        logger.warn(
           `Failed to update sfdx-project.json. Could not find package for ${version.Package2Id}. This should never happen.`
         );
       }
     } else {
-      getLogger().info(
+      logger.info(
         `Could not find Package2Version record for ${subscriberPackageVersionId}. No updates to sfdx-project.json will be made.`
       );
     }
   } catch (e) {
     const msg = e instanceof Error ? e.message : e;
-    getLogger().error(
+    logger.error(
       `Encountered error trying to update sfdx-project.json after retrieving package version metadata: ${msg as string}`
     );
   }

--- a/src/package1/package1Version.ts
+++ b/src/package1/package1Version.ts
@@ -28,7 +28,7 @@ const messages = Messages.loadMessages('@salesforce/packaging', 'package1Version
  *
  * `const pkgList = await Package1Version.list(connection);`
  *
- * Create a new 1GP package vesion in the org:
+ * Create a new 1GP package version in the org:
  *
  * `const myPkg = await Package1Version.create(connection, options, pollingOptions);`
  *

--- a/src/package1/package1Version.ts
+++ b/src/package1/package1Version.ts
@@ -70,13 +70,7 @@ export class Package1Version implements IPackageVersion1GP {
       if (pollingOptions.timeout.seconds) {
         const timeout = pollingOptions.timeout.seconds;
         const pollingClient = await PollingClient.create({
-          poll: () =>
-            Package1Version.packageUploadPolling(
-              connection,
-              createRequest.id,
-              timeout,
-              pollingOptions.frequency.seconds
-            ),
+          poll: () => packageUploadPolling(connection, createRequest.id, timeout, pollingOptions.frequency.seconds),
           ...pollingOptions,
         });
         return pollingClient.subscribe<PackagingSObjects.PackageUploadRequest>();
@@ -134,36 +128,6 @@ export class Package1Version implements IPackageVersion1GP {
     )?.records;
   }
 
-  private static async packageUploadPolling(
-    connection: Connection,
-    id: string,
-    timeout: number,
-    frequency: number
-  ): Promise<StatusResult> {
-    const pollingResult = await connection.tooling.sobject('PackageUploadRequest').retrieve(id);
-    switch (pollingResult.Status) {
-      case 'SUCCESS':
-        return { completed: true, payload: pollingResult };
-      case 'IN_PROGRESS':
-      case 'QUEUED':
-        timeout -= frequency;
-        await Lifecycle.getInstance().emit(Package1VersionEvents.create.progress, { timeout, pollingResult });
-
-        return { completed: false, payload: pollingResult };
-      default: {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        const errors = pollingResult?.Errors?.errors as Error[];
-        if (errors?.length > 0) {
-          throw messages.createError('package1VersionCreateCommandUploadFailure', [
-            errors.map((e: Error) => e.message).join(os.EOL),
-          ]);
-        } else {
-          throw messages.createError('package1VersionCreateCommandUploadFailureDefault');
-        }
-      }
-    }
-  }
-
   /**
    * Queries the org for the package version with the given ID
    */
@@ -172,3 +136,32 @@ export class Package1Version implements IPackageVersion1GP {
     return (await this.connection.tooling.query<PackagingSObjects.MetadataPackageVersion>(query)).records;
   }
 }
+
+const packageUploadPolling = async (
+  connection: Connection,
+  id: string,
+  timeout: number,
+  frequency: number
+): Promise<StatusResult> => {
+  const pollingResult = await connection.tooling.sobject('PackageUploadRequest').retrieve(id);
+  switch (pollingResult.Status) {
+    case 'SUCCESS':
+      return { completed: true, payload: pollingResult };
+    case 'IN_PROGRESS':
+    case 'QUEUED':
+      timeout -= frequency;
+      await Lifecycle.getInstance().emit(Package1VersionEvents.create.progress, { timeout, pollingResult });
+      return { completed: false, payload: pollingResult };
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const errors = pollingResult?.Errors?.errors as Error[];
+      if (errors?.length > 0) {
+        throw messages.createError('package1VersionCreateCommandUploadFailure', [
+          errors.map((e: Error) => e.message).join(os.EOL),
+        ]);
+      } else {
+        throw messages.createError('package1VersionCreateCommandUploadFailureDefault');
+      }
+    }
+  }
+};

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -514,7 +514,7 @@ export function copyDescriptorProperties(
 }
 
 /**
- * Brand new SFDX projects contain a force-app directory tree contiaining empty folders
+ * Brand new SFDX projects contain a force-app directory tree containing empty folders
  * and a few .eslintrc.json files. We still want to consider such a directory tree
  * as 'empty' for the sake of operations like downloading package version metadata.
  *

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -60,7 +60,7 @@ export const DEFAULT_PACKAGE_DIR = {
   versionName: 'ver 0.1',
   versionNumber: '0.1.0.NEXT',
   default: true,
-};
+}
 
 export const BY_LABEL = ((): IdRegistry =>
   Object.fromEntries(

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -13,7 +13,7 @@ import { randomBytes } from 'node:crypto';
 import { Connection, Logger, Messages, ScratchOrgInfo, SfdcUrl, SfError, SfProject } from '@salesforce/core';
 import { isNumber, Many, Nullable, Optional } from '@salesforce/ts-types';
 import type { SaveError } from '@jsforce/jsforce-node';
-import { Duration, ensureArray, isEmpty } from '@salesforce/kit';
+import { Duration, ensureArray } from '@salesforce/kit';
 import globby from 'globby';
 import JSZIP from 'jszip';
 import { PackageDescriptorJson, PackageType, PackagingSObjects } from '../interfaces';
@@ -51,16 +51,6 @@ export const INSTALL_URL_BASE = new SfdcUrl('https://login.salesforce.com/packag
 
 // https://developer.salesforce.com/docs/atlas.en-us.salesforce_app_limits_cheatsheet.meta/salesforce_app_limits_cheatsheet/salesforce_app_limits_platform_soslsoql.htm
 const SOQL_WHERE_CLAUSE_MAX_LENGTH = 4000;
-
-export const POLL_INTERVAL_SECONDS = 30;
-
-export const DEFAULT_PACKAGE_DIR = {
-  path: '',
-  package: '',
-  versionName: 'ver 0.1',
-  versionNumber: '0.1.0.NEXT',
-  default: true,
-}
 
 export const BY_LABEL = ((): IdRegistry =>
   Object.fromEntries(
@@ -521,10 +511,6 @@ export function copyDescriptorProperties(
       )
     )
   ) as PackageDescriptorJson;
-}
-
-export function replaceIfEmpty<T>(value: T, replacement: T): T {
-  return !isEmpty(value) ? value : replacement;
 }
 
 /**

--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -11,7 +11,7 @@ import { pipeline as cbPipeline } from 'node:stream';
 import util, { promisify } from 'node:util';
 import { randomBytes } from 'node:crypto';
 import { Connection, Logger, Messages, ScratchOrgInfo, SfdcUrl, SfError, SfProject } from '@salesforce/core';
-import { isNumber, Many, Nullable, Optional } from '@salesforce/ts-types';
+import { isNumber, isString, Many, Nullable, Optional } from '@salesforce/ts-types';
 import type { SaveError } from '@jsforce/jsforce-node';
 import { Duration, ensureArray } from '@salesforce/kit';
 import globby from 'globby';
@@ -218,7 +218,7 @@ export async function getContainerOptions(
   packageIds: string | undefined | Array<string | undefined>,
   connection: Connection
 ): Promise<Map<string, PackageType>> {
-  const ids = ensureArray(packageIds).filter((id) => id) as string[];
+  const ids = ensureArray(packageIds).filter(isString);
   if (ids.length === 0) {
     return new Map<string, PackageType>();
   }
@@ -497,8 +497,8 @@ export function copyDescriptorProperties(
   packageDescriptorJson: PackageDescriptorJson,
   definitionFileJson: ScratchOrgInfo
 ): PackageDescriptorJson {
-  const packageDescriptorJsonCopy = Object.assign({}, packageDescriptorJson) as Record<string, unknown>;
-  const definitionFileJsonCopy = Object.assign({}, definitionFileJson) as unknown as { [key: string]: unknown };
+  const packageDescriptorJsonCopy = structuredClone(packageDescriptorJson);
+  const definitionFileJsonCopy = structuredClone(definitionFileJson) as unknown as { [key: string]: unknown };
   return Object.assign(
     {},
     packageDescriptorJsonCopy,

--- a/test/package/ancestry.nut.ts
+++ b/test/package/ancestry.nut.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import os from 'node:os';
+import path from 'node:path';
+import { expect, config } from 'chai';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { SfProject } from '@salesforce/core/project';
+import { Org } from '@salesforce/core';
+import {
+  AncestryRepresentationProducer,
+  AncestryRepresentationProducerOptions,
+  PackagingSObjects,
+} from '../../src/exported';
+import { VersionNumber } from '../../src/package/versionNumber';
+import { AncestryJsonProducer, AncestryTreeProducer, PackageAncestry } from '../../src/package/packageAncestry';
+
+let session: TestSession;
+config.truncateThreshold = 0;
+describe('ancestry tests', () => {
+  type PackageVersionQueryResult = PackagingSObjects.Package2Version & {
+    Package2: {
+      Id: string;
+      Name: string;
+      NamespacePrefix: string;
+    };
+  };
+  let project: SfProject;
+  let devHubOrg: Org;
+  let pkgName: string;
+  let versions: VersionNumber[];
+  let sortedVersions: VersionNumber[];
+  let aliases: { [alias: string]: string };
+
+  before('ancestry project setup', async () => {
+    const query =
+      "SELECT AncestorId, SubscriberPackageVersionId, MajorVersion, MinorVersion, PatchVersion, BuildNumber, Package2Id, Package2.Name, package2.NamespacePrefix FROM Package2Version where package2.containeroptions = 'Managed' AND IsReleased = true";
+
+    // will auth the hub
+    session = await TestSession.create({
+      project: {
+        sourceDir: path.join('test', 'package', 'resources', 'packageProject'),
+      },
+      devhubAuthStrategy: 'AUTO',
+    });
+    execCmd('config:set restDeploy=false', { ensureExitCode: 0, cli: 'sf' });
+
+    devHubOrg = await Org.create({ aliasOrUsername: session.hubOrg.username });
+    const queryRecords = (await devHubOrg.getConnection().tooling.query<PackageVersionQueryResult>(query)).records;
+
+    // preferred well known package pnhcoverage3, but if it's not available, use the first one
+    pkgName = queryRecords.some((pv) => pv.Package2.Name === 'pnhcoverage3')
+      ? 'pnhcoverage3'
+      : queryRecords[0].Package2.Name;
+
+    const pvRecords = queryRecords.filter((pv) => pv.Package2.Name === pkgName);
+    versions = pvRecords.map(
+      (pv) => new VersionNumber(pv.MajorVersion, pv.MinorVersion, pv.PatchVersion, pv.BuildNumber)
+    );
+    sortedVersions = [...versions].sort((a, b) => a.compareTo(b));
+    project = await SfProject.resolve();
+    const pjson = project.getSfProjectJson();
+    const pkg = {
+      ...project.getDefaultPackage(),
+      package: pkgName,
+      versionNumber: sortedVersions[0].toString(),
+      versionName: 'v1',
+    };
+
+    pjson.set('packageDirectories', [pkg]);
+    aliases = Object.fromEntries([
+      ...pvRecords.map((pv, index) => [
+        `${pv.Package2.Name}@${versions[index].toString()}`,
+        pv.SubscriberPackageVersionId,
+      ]),
+      [pkgName, pvRecords[0].Package2Id],
+    ]) as { [alias: string]: string };
+    pjson.set('packageAliases', aliases);
+    pjson.set('namespace', pvRecords[0].Package2.NamespacePrefix);
+    await pjson.write();
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+  it('should have a correct project config', async () => {
+    expect(project.getSfProjectJson().get('packageAliases')).to.have.property(pkgName);
+  });
+  it('should produce a json representation of the ancestor tree from package name (0Ho)', async () => {
+    const pa = await PackageAncestry.create({ packageId: pkgName, project, connection: devHubOrg.getConnection() });
+    expect(pa).to.be.ok;
+    const jsonProducer = pa.getRepresentationProducer(
+      (opts: AncestryRepresentationProducerOptions) => new AncestryJsonProducer(opts),
+      undefined
+    );
+    expect(jsonProducer).to.be.ok;
+    const jsonTree = jsonProducer.produce();
+    expect(jsonTree).to.have.property('data');
+    expect(jsonTree).to.have.property('children');
+  });
+  it('should produce a graphic representation of the ancestor tree from package name (0Ho)', async () => {
+    const pa = await PackageAncestry.create({ packageId: pkgName, project, connection: devHubOrg.getConnection() });
+    expect(pa).to.be.ok;
+
+    class TestAncestryTreeProducer extends AncestryTreeProducer implements AncestryRepresentationProducer {
+      public static treeAsText: string;
+
+      public constructor(options?: AncestryRepresentationProducerOptions) {
+        super(options);
+      }
+    }
+
+    const treeProducer = pa.getRepresentationProducer(
+      (opts: AncestryRepresentationProducerOptions) =>
+        new TestAncestryTreeProducer({
+          ...opts,
+          logger: (text: string) => (TestAncestryTreeProducer.treeAsText = text),
+        }),
+      undefined
+    );
+    expect(treeProducer).to.be.ok;
+    treeProducer.produce();
+    const treeText = TestAncestryTreeProducer.treeAsText.split(os.EOL);
+    expect(treeText[0]).to.match(new RegExp(`^└─ ${sortedVersions[0].toString()}`));
+  });
+  it('should produce a verbose graphic representation of the ancestor tree from package name (0Ho)', async () => {
+    const pa = await PackageAncestry.create({ packageId: pkgName, project, connection: devHubOrg.getConnection() });
+    expect(pa).to.be.ok;
+
+    class TestAncestryTreeProducer extends AncestryTreeProducer implements AncestryRepresentationProducer {
+      public static treeAsText: string;
+
+      public constructor(options?: AncestryRepresentationProducerOptions) {
+        super(options);
+      }
+    }
+
+    const treeProducer = pa.getRepresentationProducer(
+      (opts: AncestryRepresentationProducerOptions) =>
+        new TestAncestryTreeProducer({
+          ...opts,
+          logger: (text: string) => (TestAncestryTreeProducer.treeAsText = text),
+          verbose: true,
+        }),
+      undefined
+    );
+    expect(treeProducer).to.be.ok;
+    treeProducer.produce();
+    const treeText = TestAncestryTreeProducer.treeAsText.split(os.EOL);
+    expect(treeText[0]).to.match(new RegExp(`^└─ ${sortedVersions[0].toString()} \\(04t.{12,15}\\)`));
+  });
+  it('should get path from leaf to root', async () => {
+    const pa = await PackageAncestry.create({ packageId: pkgName, project, connection: devHubOrg.getConnection() });
+    expect(pa).to.be.ok;
+    const graph = pa.getAncestryGraph();
+    const root = graph.findNode((n) => graph.inDegree(n) === 0);
+    const subIds: string[] = Object.values(project.getSfProjectJson().getContents().packageAliases ?? []).filter(
+      (id: string) => id.startsWith('04t')
+    );
+    const leaf = subIds[subIds.length - 1];
+    const pathsToRoots = pa.getLeafPathToRoot(leaf);
+    expect(pathsToRoots).to.be.ok;
+    expect(pathsToRoots).to.have.lengthOf(1);
+    expect(pathsToRoots[0][0].SubscriberPackageVersionId).to.equal(leaf);
+    expect(pathsToRoots[0][pathsToRoots[0].length - 1].getVersion()).to.equal(root);
+  });
+});

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -4,7 +4,6 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { expect, assert } from 'chai';
@@ -14,8 +13,6 @@ import { ProjectJson, isPackagingDirectory } from '@salesforce/core/project';
 import { Lifecycle, Org, SfProject } from '@salesforce/core';
 import { uniqid } from '@salesforce/core/testSetup';
 import {
-  AncestryRepresentationProducer,
-  AncestryRepresentationProducerOptions,
   Package,
   PackageCreateOptions,
   PackageVersion,
@@ -27,8 +24,7 @@ import {
   Package2VersionFieldTypes,
 } from '../../src/exported';
 import { PackageEvents } from '../../src/interfaces';
-import { SubscriberPackageVersion, VersionNumber } from '../../src/package';
-import { AncestryJsonProducer, AncestryTreeProducer, PackageAncestry } from '../../src/package/packageAncestry';
+import { SubscriberPackageVersion } from '../../src/package';
 
 let session: TestSession;
 
@@ -555,153 +551,5 @@ describe('Integration tests for @salesforce/packaging library', () => {
       expect(result.success).to.be.true;
       expect(result.id).to.be.equal(pkgId);
     });
-  });
-});
-describe('ancestry tests', () => {
-  type PackageVersionQueryResult = PackagingSObjects.Package2Version & {
-    Package2: {
-      Id: string;
-      Name: string;
-      NamespacePrefix: string;
-    };
-  };
-  let project: SfProject;
-  let devHubOrg: Org;
-  let pkgName: string;
-  let versions: VersionNumber[];
-  let sortedVersions: VersionNumber[];
-  let aliases: { [alias: string]: string };
-
-  before('ancestry project setup', async () => {
-    const query =
-      "SELECT AncestorId, SubscriberPackageVersionId, MajorVersion, MinorVersion, PatchVersion, BuildNumber, Package2Id, Package2.Name, package2.NamespacePrefix FROM Package2Version where package2.containeroptions = 'Managed' AND IsReleased = true";
-
-    execCmd('config:set restDeploy=false', { cli: 'sfdx' });
-    process.env.TESTKIT_EXECUTABLE_PATH = 'sfdx';
-    // will auth the hub
-    session = await TestSession.create({
-      project: {
-        sourceDir: path.join('test', 'package', 'resources', 'packageProject'),
-      },
-      devhubAuthStrategy: 'AUTO',
-    });
-    devHubOrg = await Org.create({ aliasOrUsername: session.hubOrg.username });
-    let pvRecords = (await devHubOrg.getConnection().tooling.query<PackageVersionQueryResult>(query)).records;
-    // preferred well known package pnhcoverage3, but if it's not available, use the first one
-    if (pvRecords.some((pv) => pv.Package2.Name === 'pnhcoverage3')) {
-      pkgName = 'pnhcoverage3';
-    } else {
-      pkgName = pvRecords[0].Package2.Name;
-    }
-    pvRecords = pvRecords.filter((pv) => pv.Package2.Name === pkgName);
-    versions = pvRecords.map(
-      (pv) => new VersionNumber(pv.MajorVersion, pv.MinorVersion, pv.PatchVersion, pv.BuildNumber)
-    );
-    sortedVersions = [...versions].sort((a, b) => a.compareTo(b));
-    project = await SfProject.resolve();
-    const pjson = project.getSfProjectJson();
-    const pkg = project.getDefaultPackage();
-    assert(isPackagingDirectory(pkg));
-
-    pkg.package = pkgName;
-    pkg.versionNumber = sortedVersions[0].toString();
-    pkg.versionName = 'v1';
-    pjson.set('packageDirectories', [pkg]);
-    aliases = Object.fromEntries([
-      ...pvRecords.map((pv, index) => [
-        `${pv.Package2.Name}@${versions[index].toString()}`,
-        pv.SubscriberPackageVersionId,
-      ]),
-      [pkgName, pvRecords[0].Package2Id],
-    ]) as { [alias: string]: string };
-    pjson.set('packageAliases', aliases);
-    pjson.set('namespace', pvRecords[0].Package2.NamespacePrefix);
-    await pjson.write();
-  });
-
-  after(async () => {
-    await session?.zip();
-    await session?.clean();
-  });
-  it('should have a correct project config', async () => {
-    expect(project.getSfProjectJson().get('packageAliases')).to.have.property(pkgName);
-  });
-  it('should produce a json representation of the ancestor tree from package name (0Ho)', async () => {
-    const pa = await PackageAncestry.create({ packageId: pkgName, project, connection: devHubOrg.getConnection() });
-    expect(pa).to.be.ok;
-    const jsonProducer = pa.getRepresentationProducer(
-      (opts: AncestryRepresentationProducerOptions) => new AncestryJsonProducer(opts),
-      undefined
-    );
-    expect(jsonProducer).to.be.ok;
-    const jsonTree = jsonProducer.produce();
-    expect(jsonTree).to.have.property('data');
-    expect(jsonTree).to.have.property('children');
-  });
-  it('should produce a graphic representation of the ancestor tree from package name (0Ho)', async () => {
-    const pa = await PackageAncestry.create({ packageId: pkgName, project, connection: devHubOrg.getConnection() });
-    expect(pa).to.be.ok;
-
-    class TestAncestryTreeProducer extends AncestryTreeProducer implements AncestryRepresentationProducer {
-      public static treeAsText: string;
-
-      public constructor(options?: AncestryRepresentationProducerOptions) {
-        super(options);
-      }
-    }
-
-    const treeProducer = pa.getRepresentationProducer(
-      (opts: AncestryRepresentationProducerOptions) =>
-        new TestAncestryTreeProducer({
-          ...opts,
-          logger: (text: string) => (TestAncestryTreeProducer.treeAsText = text),
-        }),
-      undefined
-    );
-    expect(treeProducer).to.be.ok;
-    treeProducer.produce();
-    const treeText = TestAncestryTreeProducer.treeAsText.split(os.EOL);
-    expect(treeText[0]).to.match(new RegExp(`^└─ ${sortedVersions[0].toString()}`));
-  });
-  it('should produce a verbose graphic representation of the ancestor tree from package name (0Ho)', async () => {
-    const pa = await PackageAncestry.create({ packageId: pkgName, project, connection: devHubOrg.getConnection() });
-    expect(pa).to.be.ok;
-
-    class TestAncestryTreeProducer extends AncestryTreeProducer implements AncestryRepresentationProducer {
-      public static treeAsText: string;
-
-      public constructor(options?: AncestryRepresentationProducerOptions) {
-        super(options);
-      }
-    }
-
-    const treeProducer = pa.getRepresentationProducer(
-      (opts: AncestryRepresentationProducerOptions) =>
-        new TestAncestryTreeProducer({
-          ...opts,
-          logger: (text: string) => (TestAncestryTreeProducer.treeAsText = text),
-          verbose: true,
-        }),
-      undefined
-    );
-    expect(treeProducer).to.be.ok;
-    treeProducer.produce();
-    const treeText = TestAncestryTreeProducer.treeAsText.split(os.EOL);
-    expect(treeText[0]).to.match(new RegExp(`^└─ ${sortedVersions[0].toString()} \\(04t.{12,15}\\)`));
-  });
-  it('should get path from leaf to root', async () => {
-    const pa = await PackageAncestry.create({ packageId: pkgName, project, connection: devHubOrg.getConnection() });
-    expect(pa).to.be.ok;
-    const graph = pa.getAncestryGraph();
-    const root = graph.findNode((n) => graph.inDegree(n) === 0);
-    const subIds: string[] = Object.values(project.getSfProjectJson().getContents().packageAliases ?? []).filter(
-      (id: string) => id.startsWith('04t')
-    );
-    const leaf = subIds[subIds.length - 1];
-    const pathsToRoots = pa.getLeafPathToRoot(leaf);
-    expect(pathsToRoots).to.be.ok;
-    expect(pathsToRoots).to.have.lengthOf(1);
-    expect(pathsToRoots[0][0].SubscriberPackageVersionId).to.equal(leaf);
-    expect(pathsToRoots[0][pathsToRoots[0].length - 1].getVersion()).to.equal(root);
   });
 });

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -7,10 +7,10 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs/promises';
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { Duration, sleep } from '@salesforce/kit';
-import { ProjectJson } from '@salesforce/core/project';
+import { ProjectJson, isPackagingDirectory } from '@salesforce/core/project';
 import { Lifecycle, Org, SfProject } from '@salesforce/core';
 import { uniqid } from '@salesforce/core/testSetup';
 import {
@@ -128,6 +128,7 @@ describe('Integration tests for @salesforce/packaging library', () => {
       const projectFile = JSON.parse(dxPjsonData) as ProjectJson;
       expect(projectFile).to.have.property('packageDirectories').with.length(1);
       expect(projectFile.packageDirectories[0]).to.include.keys(['package', 'versionName', 'versionNumber']);
+      assert(isPackagingDirectory(projectFile.packageDirectories[0]));
       expect(projectFile.packageDirectories[0].package).to.equal(pkgName);
       expect(projectFile.packageAliases).to.deep.equal({
         [pkgName]: pkgId,
@@ -312,6 +313,7 @@ describe('Integration tests for @salesforce/packaging library', () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       const dxPjsonData = await fs.readFile(path.join(session.project.dir, 'sfdx-project.json'), 'utf8');
       const projectFile = JSON.parse(dxPjsonData) as ProjectJson;
+      assert(isPackagingDirectory(projectFile.packageDirectories[0]));
 
       expect(result.Name).to.equal(
         projectFile.packageDirectories[0].versionName,
@@ -599,6 +601,8 @@ describe('ancestry tests', () => {
     project = await SfProject.resolve();
     const pjson = project.getSfProjectJson();
     const pkg = project.getDefaultPackage();
+    assert(isPackagingDirectory(pkg));
+
     pkg.package = pkgName;
     pkg.versionNumber = sortedVersions[0].toString();
     pkg.versionName = 'v1';

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -506,7 +506,7 @@ describe('Integration tests for @salesforce/packaging library', () => {
         const pollResult = await SubscriberPackageVersion.uninstallStatus(uninstallReqId, scratchOrg.getConnection());
         if (pollResult.Status === 'InProgress' && counter < MAX_TRIES) {
           return sleep(WAIT_INTERVAL_MS, Duration.Unit.MILLISECONDS).then(() =>
-            waitForUninstallRequestAndValidate(counter++)
+            waitForUninstallRequestAndValidate(counter + 1)
           );
         } else {
           // break out of recursion, validate result

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -9,6 +9,8 @@ import fs from 'node:fs';
 import { instantiateContext, MockTestOrgData, restoreContext, stubContext } from '@salesforce/core/testSetup';
 import { assert, expect } from 'chai';
 import { Connection, Logger, SfProject } from '@salesforce/core';
+import { isPackagingDirectory } from '@salesforce/core/project';
+import { PackageDir, PackagePackageDir } from '@salesforce/schemas';
 import {
   MetadataResolver,
   PackageVersionCreate,
@@ -23,6 +25,25 @@ import { PackageProfileApi } from '../../src/package/packageProfileApi';
 import { VersionNumber } from '../../src/package/versionNumber';
 
 describe('Package Version Create', () => {
+  const expectedKeys = [
+    'Branch',
+    'CodeCoverage',
+    'ConvertedFromVersionId',
+    'CreatedBy',
+    'CreatedDate',
+    'Error',
+    'HasMetadataRemoved',
+    'HasPassedCodeCoverageCheck',
+    'Id',
+    'Package2Id',
+    'Package2Name',
+    'Package2VersionId',
+    'Status',
+    'SubscriberPackageVersionId',
+    'Tag',
+    'VersionNumber',
+  ];
+
   const $$ = instantiateContext();
   const testOrg = new MockTestOrgData();
   const packageId = '0Ho3i000000Gmj6XXX';
@@ -153,26 +174,10 @@ describe('Package Version Create', () => {
     stubConvert();
 
     const result = await pvc.createPackageVersion();
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
-
-    expect(project.getSfProjectJson().getContents().packageDirectories[1].dependencies).to.deep.equal([
+    expect(result).to.have.all.keys(expectedKeys);
+    const dir1 = project.getSfProjectJson().getContents().packageDirectories[1];
+    assert(isPackagingDirectory(dir1));
+    expect(dir1.dependencies).to.deep.equal([
       {
         package: 'DEP@0.1.0-1',
       },
@@ -185,24 +190,7 @@ describe('Package Version Create', () => {
     stubConvert();
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].CalculateCodeCoverage).to.equal(true);
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const unpackagedMD = hasUnpackagedMdSpy.secondCall.args[0];
     expect(unpackagedMD).to.equal('unpackaged');
@@ -215,24 +203,7 @@ describe('Package Version Create', () => {
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].CalculateCodeCoverage).to.equal(false);
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const hasSeedMd = hasSeedMdSpy.firstCall.args[0];
     expect(hasSeedMd).to.equal('seed');
@@ -249,24 +220,7 @@ describe('Package Version Create', () => {
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Tag).to.equal('DancingBears');
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should create the package version create request with skipancestorcheck info', async () => {
@@ -281,24 +235,7 @@ describe('Package Version Create', () => {
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].skipancestorcheck).to.equal(undefined);
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should create the package version create request with skip validation', async () => {
@@ -312,24 +249,7 @@ describe('Package Version Create', () => {
 
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].SkipValidation).to.equal(true);
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should create the package version create request with installationkey', async () => {
@@ -344,24 +264,7 @@ describe('Package Version Create', () => {
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].InstallKey).to.equal('guessMyPassword');
     expect(packageCreateStub.firstCall.args[1].SkipValidation).to.equal(false);
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should create the package version create request with branch', async () => {
@@ -369,24 +272,7 @@ describe('Package Version Create', () => {
     stubConvert();
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Branch).to.equal('main');
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should resolve dependency version using the --branch parameter only if the branch is undefined in config', async () => {
@@ -394,7 +280,7 @@ describe('Package Version Create', () => {
     const packageVersionCreateSpy = $$.SANDBOX.spy(PackageVersionCreate.prototype, 'resolveBuildNumber');
 
     const config = project.getSfProjectJson().getContents();
-    if (config.packageDirectories[1].dependencies !== undefined) {
+    if (isDirWithDependencies(config.packageDirectories[1])) {
       config.packageDirectories[1].dependencies[0].package = 'DEP';
       config.packageDirectories[1].dependencies[0].versionNumber = '0.1.0.1';
     }
@@ -418,24 +304,7 @@ describe('Package Version Create', () => {
       true
     );
 
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should resolve dependency version ignoring the --branch parameter if the branch is explicitly set in config', async () => {
@@ -443,7 +312,7 @@ describe('Package Version Create', () => {
     const packageVersionCreateSpy = $$.SANDBOX.spy(PackageVersionCreate.prototype, 'resolveBuildNumber');
 
     const config = project.getSfProjectJson().getContents();
-    if (config.packageDirectories[1].dependencies !== undefined) {
+    if (isDirWithDependencies(config.packageDirectories[1])) {
       config.packageDirectories[1].dependencies[0].package = 'DEP';
       config.packageDirectories[1].dependencies[0].versionNumber = '0.1.0.1';
       config.packageDirectories[1].dependencies[0].branch = 'dev';
@@ -467,24 +336,7 @@ describe('Package Version Create', () => {
       true
     );
 
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it("should resolve dependency version to `null` if the --branch parameter is set but the branch is explicitly '' in config", async () => {
@@ -492,7 +344,7 @@ describe('Package Version Create', () => {
     const packageVersionCreateSpy = $$.SANDBOX.spy(PackageVersionCreate.prototype, 'resolveBuildNumber');
 
     const config = project.getSfProjectJson().getContents();
-    if (config.packageDirectories[1].dependencies !== undefined) {
+    if (isDirWithDependencies(config.packageDirectories[1])) {
       config.packageDirectories[1].dependencies[0].package = 'DEP';
       config.packageDirectories[1].dependencies[0].versionNumber = '0.1.0.1';
       config.packageDirectories[1].dependencies[0].branch = '';
@@ -514,24 +366,7 @@ describe('Package Version Create', () => {
     // @ts-ignore: Expected 0 arguments, but got 3
     expect(packageVersionCreateSpy.calledWith(VersionNumber.from('0.1.0.1'), '0Ho4J000000TNmPXXX', '')).to.equal(true);
 
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should create the package version create request with language and API version >= 57.0', async () => {
@@ -540,24 +375,7 @@ describe('Package Version Create', () => {
     stubConvert();
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Language).to.equal('en_US');
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should NOT create the package version create request with language and API version < 57.0', async () => {
@@ -566,24 +384,7 @@ describe('Package Version Create', () => {
     const pvc = new PackageVersionCreate({ connection, project, language: 'en_US', packageId });
     const result = await pvc.createPackageVersion();
     expect(packageCreateStub.firstCall.args[1].Language).to.be.undefined;
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it("should set the build org language (i.e., package2-descriptor.json's language) from the scratch org definition file's language", async () => {
@@ -597,24 +398,7 @@ describe('Package Version Create', () => {
 
     const pvc = new PackageVersionCreate({ connection, project, definitionfile: scratchOrgDefFileName, packageId });
     const result = await pvc.createPackageVersion();
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
@@ -652,24 +436,7 @@ describe('Package Version Create', () => {
 
     const result = await pvc.createPackageVersion();
     expect(validationSpy.callCount).to.equal(1);
-    expect(result).to.have.all.keys(
-      'Branch',
-      'CodeCoverage',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag',
-      'VersionNumber'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
 
     const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
     expect(package2DescriptorJson).to.have.string('packageMetadataPermissionSetNames');
@@ -804,24 +571,7 @@ describe('Package Version Create', () => {
 
     const result = await pvc.createPackageVersion();
     expect(validationSpy.callCount).to.equal(1);
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
   });
 
   it('should not package the profiles from unpackaged metadata dirs', async () => {
@@ -874,24 +624,7 @@ describe('Package Version Create', () => {
     const profileSpyFilter = $$.SANDBOX.spy(PackageProfileApi.prototype, 'filterAndGenerateProfilesForManifest');
     stubConvert();
     const result = await pvc.createPackageVersion();
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const excludedDirsGenerate = profileSpyGenerate.firstCall.args[2];
     expect(excludedDirsGenerate?.length).to.equal(2);
@@ -956,24 +689,7 @@ describe('Package Version Create', () => {
     stubConvert();
     const result = await pvc.createPackageVersion();
 
-    expect(result).to.have.all.keys(
-      'Branch',
-      'ConvertedFromVersionId',
-      'CreatedBy',
-      'CreatedDate',
-      'Error',
-      'HasMetadataRemoved',
-      'HasPassedCodeCoverageCheck',
-      'CodeCoverage',
-      'VersionNumber',
-      'Id',
-      'Package2Id',
-      'Package2Name',
-      'Package2VersionId',
-      'Status',
-      'SubscriberPackageVersionId',
-      'Tag'
-    );
+    expect(result).to.have.all.keys(expectedKeys);
     expect(loggerSpy.called).to.be.true;
     const logMsg =
       "packageDirectory: force-app has 'scopeProfiles' set, so only including profiles from within this directory";
@@ -1123,24 +839,7 @@ describe('Package Version Create', () => {
 
       const pvc = new PackageVersionCreate({ connection, project, definitionfile: scratchOrgDefFileName, packageId });
       const result = await pvc.createPackageVersion();
-      expect(result).to.have.all.keys(
-        'Branch',
-        'CodeCoverage',
-        'ConvertedFromVersionId',
-        'CreatedBy',
-        'CreatedDate',
-        'Error',
-        'HasMetadataRemoved',
-        'HasPassedCodeCoverageCheck',
-        'Id',
-        'Package2Id',
-        'Package2Name',
-        'Package2VersionId',
-        'Status',
-        'SubscriberPackageVersionId',
-        'Tag',
-        'VersionNumber'
-      );
+      expect(result).to.have.all.keys(expectedKeys);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
@@ -1158,24 +857,7 @@ describe('Package Version Create', () => {
 
       const pvc = new PackageVersionCreate({ connection, project, definitionfile: scratchOrgDefFileName, packageId });
       const result = await pvc.createPackageVersion();
-      expect(result).to.have.all.keys(
-        'Branch',
-        'CodeCoverage',
-        'ConvertedFromVersionId',
-        'CreatedBy',
-        'CreatedDate',
-        'Error',
-        'HasMetadataRemoved',
-        'HasPassedCodeCoverageCheck',
-        'Id',
-        'Package2Id',
-        'Package2Name',
-        'Package2VersionId',
-        'Status',
-        'SubscriberPackageVersionId',
-        'Tag',
-        'VersionNumber'
-      );
+      expect(result).to.have.all.keys(expectedKeys);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const package2DescriptorJson = writeFileSpy.firstCall.args[1]; // package2-descriptor.json contents
@@ -1260,3 +942,8 @@ describe('PackageXml read/write', () => {
     });
   });
 });
+
+const isDirWithDependencies = (
+  dir: PackageDir
+): dir is PackagePackageDir & Required<Pick<PackagePackageDir, 'dependencies'>> =>
+  isPackagingDirectory(dir) && dir.dependencies !== undefined;

--- a/test/package/subscriberPackageVersion.test.ts
+++ b/test/package/subscriberPackageVersion.test.ts
@@ -9,7 +9,6 @@ import fs from 'node:fs';
 import { Connection, SfProject } from '@salesforce/core';
 import { expect } from 'chai';
 import { instantiateContext, MockTestOrgData, restoreContext, stubContext } from '@salesforce/core/testSetup';
-import { Optional } from '@salesforce/ts-types';
 import { SubscriberPackageVersion } from '../../src/package';
 import { PackagingSObjects } from '../../src/interfaces';
 
@@ -74,7 +73,7 @@ async function setupProject(setup: (project: SfProject) => void = () => {}) {
 
 describe('subscriberPackageVersion', () => {
   const testOrg = new MockTestOrgData();
-  const password: Optional<string> = undefined;
+  const password: string | undefined = undefined;
   let connection: Connection;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,30 +586,6 @@
     semver "^7.6.2"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^7.3.12":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.4.0.tgz#11c45a5f432e032bf242aaace1a175779e3e096f"
-  integrity sha512-wn3fJnpG8h493qKR52Il3xgRbXg4zwbV34wonf/mTZP3n5rJeC/7S69249CGN155Os6Lds5rEUo3pGJFwgCBdQ==
-  dependencies:
-    "@jsforce/jsforce-node" "^3.2.0"
-    "@salesforce/kit" "^3.1.2"
-    "@salesforce/schemas" "^1.9.0"
-    "@salesforce/ts-types" "^2.0.9"
-    ajv "^8.15.0"
-    change-case "^4.1.2"
-    fast-levenshtein "^3.0.0"
-    faye "^1.4.0"
-    form-data "^4.0.0"
-    js2xmlparser "^4.0.1"
-    jsonwebtoken "9.0.2"
-    jszip "3.10.1"
-    pino "^8.21.0"
-    pino-abstract-transport "^1.2.0"
-    pino-pretty "^10.3.1"
-    proper-lockfile "^4.1.2"
-    semver "^7.6.2"
-    ts-retry-promise "^0.8.1"
-
 "@salesforce/dev-config@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-4.1.0.tgz#e529576466d074e7a5f1441236510fef123da01e"
@@ -647,7 +623,7 @@
     typescript "^5.4.3"
     wireit "^0.14.4"
 
-"@salesforce/kit@^3.1.1", "@salesforce/kit@^3.1.2", "@salesforce/kit@^3.1.6":
+"@salesforce/kit@^3.1.6":
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.6.tgz#aefb39c0e0f325e11f80551ff92cf6979dd74070"
   integrity sha512-zAYPmCSAvdonDOnL5AzuVRVv0sRMlQd6gi12HDE1964VqSjt5pzlLU90thh3Qq4A1Wxbdu0FbHYx9BvZ4fWPvQ==
@@ -664,13 +640,13 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^11.6.6":
-  version "11.6.6"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.6.6.tgz#0bec970d04cd528f68ae9009bdd52ec1db20a6b5"
-  integrity sha512-Wf7QCYtFsBwyLAFSPPuonyUnFMIz113yabDmZd9bBEeH3dKqPFQb6zHAV3HpoU5hwvHN/+xE8QDSxv3yjtyFPw==
+"@salesforce/source-deploy-retrieve@^12.0.1":
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.0.1.tgz#9cfcde127e0bf57a76beb2b1450edf2d44957d0f"
+  integrity sha512-LwbOBwmkXk+zYQBU7VfmlLA8jSF7vgdaSSVzKtqaQDWbHUms+EW5oNMr2ELD8wN7Grh0tlTcHA4sSP305jqdXA==
   dependencies:
-    "@salesforce/core" "^7.3.12"
-    "@salesforce/kit" "^3.1.1"
+    "@salesforce/core" "^8.0.1"
+    "@salesforce/kit" "^3.1.6"
     "@salesforce/ts-types" "^2.0.9"
     fast-levenshtein "^3.0.0"
     fast-xml-parser "^4.3.6"
@@ -2320,7 +2296,7 @@ extend@^3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-fast-copy@^3.0.0, fast-copy@^3.0.2:
+fast-copy@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
   integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
@@ -4325,26 +4301,6 @@ pino-abstract-transport@^1.0.0, pino-abstract-transport@^1.2.0:
     readable-stream "^4.0.0"
     split2 "^4.0.0"
 
-pino-pretty@^10.3.1:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-10.3.1.tgz#e3285a5265211ac6c7cd5988f9e65bf3371a0ca9"
-  integrity sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==
-  dependencies:
-    colorette "^2.0.7"
-    dateformat "^4.6.3"
-    fast-copy "^3.0.0"
-    fast-safe-stringify "^2.1.1"
-    help-me "^5.0.0"
-    joycon "^3.1.1"
-    minimist "^1.2.6"
-    on-exit-leak-free "^2.1.0"
-    pino-abstract-transport "^1.0.0"
-    pump "^3.0.0"
-    readable-stream "^4.0.0"
-    secure-json-parse "^2.4.0"
-    sonic-boom "^3.0.0"
-    strip-json-comments "^3.1.1"
-
 pino-pretty@^11.2.1:
   version "11.2.1"
   resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-11.2.1.tgz#de9a42ff8ea7b26da93506bb9e49d0b566c5ae96"
@@ -4365,32 +4321,10 @@ pino-pretty@^11.2.1:
     sonic-boom "^4.0.1"
     strip-json-comments "^3.1.1"
 
-pino-std-serializers@^6.0.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz#d9a9b5f2b9a402486a5fc4db0a737570a860aab3"
-  integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
-
 pino-std-serializers@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz#7c625038b13718dbbd84ab446bd673dc52259e3b"
   integrity sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==
-
-pino@^8.21.0:
-  version "8.21.0"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-8.21.0.tgz#e1207f3675a2722940d62da79a7a55a98409f00d"
-  integrity sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==
-  dependencies:
-    atomic-sleep "^1.0.0"
-    fast-redact "^3.1.1"
-    on-exit-leak-free "^2.1.0"
-    pino-abstract-transport "^1.2.0"
-    pino-std-serializers "^6.0.0"
-    process-warning "^3.0.0"
-    quick-format-unescaped "^4.0.3"
-    real-require "^0.2.0"
-    safe-stable-stringify "^2.3.1"
-    sonic-boom "^3.7.0"
-    thread-stream "^2.6.0"
 
 pino@^9.2.0:
   version "9.2.0"
@@ -4973,13 +4907,6 @@ socks@^2.7.1:
     ip "^2.0.0"
     smart-buffer "^4.2.0"
 
-sonic-boom@^3.0.0, sonic-boom@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.7.0.tgz#b4b7b8049a912986f4a92c51d4660b721b11f2f2"
-  integrity sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==
-  dependencies:
-    atomic-sleep "^1.0.0"
-
 sonic-boom@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.0.1.tgz#515b7cef2c9290cb362c4536388ddeece07aed30"
@@ -5217,13 +5144,6 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
-
-thread-stream@^2.6.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.7.0.tgz#d8a8e1b3fd538a6cca8ce69dbe5d3d097b601e11"
-  integrity sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==
-  dependencies:
-    real-require "^0.2.0"
 
 thread-stream@^3.0.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,10 +562,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@7.3.12-qa.0":
-  version "7.3.12-qa.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.12-qa.0.tgz#230f461925f925634de3ad0c54c62a2915e8457e"
-  integrity sha512-XTmthlRLtYUUd4YgYMS3T6xl5WM2iDTnpNf/BVzAdtSpcOluRDIfeN70kNtUniYaXrSfWWes/gessjaRnpE7eQ==
+"@salesforce/core@7.3.12-qa.1":
+  version "7.3.12-qa.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.12-qa.1.tgz#4d186193b2766b40e1926e0191b6270a82055587"
+  integrity sha512-TX0wNurO0rPopJrAz3B/Oe/y2qK3rT/3g3KDBE6vuIXOufXVVUwyRo+TgbY764GBHnc0emxntE9PHdUv6L+hWQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.2.0"
     "@salesforce/kit" "^3.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,6 +562,30 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
+"@salesforce/core@7.3.12-qa.0":
+  version "7.3.12-qa.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.12-qa.0.tgz#230f461925f925634de3ad0c54c62a2915e8457e"
+  integrity sha512-XTmthlRLtYUUd4YgYMS3T6xl5WM2iDTnpNf/BVzAdtSpcOluRDIfeN70kNtUniYaXrSfWWes/gessjaRnpE7eQ==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.2.0"
+    "@salesforce/kit" "^3.1.2"
+    "@salesforce/schemas" "^1.9.0"
+    "@salesforce/ts-types" "^2.0.9"
+    ajv "^8.15.0"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.2"
+    jszip "3.10.1"
+    pino "^8.21.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^10.3.1"
+    proper-lockfile "^4.1.2"
+    semver "^7.6.2"
+    ts-retry-promise "^0.8.1"
+
 "@salesforce/core@^7.3.12", "@salesforce/core@^7.3.9":
   version "7.3.12"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.12.tgz#9138980db21566c467f35afe9192f33bf77f160c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5074,16 +5074,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5142,14 +5133,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5622,7 +5606,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5635,15 +5619,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,28 +562,29 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^7.3.9":
-  version "7.3.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.9.tgz#8abe2b3e2393989d11e92b7a6b96043fc9d5b9c8"
-  integrity sha512-eJqDiA5b7wU50Ee/xjmGzSnHrNVJ8S77B7enfX30gm7gxU3i3M3QeBdiV6XAOPLSIL96DseofP6Tv6c+rljlKA==
+"@salesforce/core@^7.3.12", "@salesforce/core@^7.3.9":
+  version "7.3.12"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.12.tgz#9138980db21566c467f35afe9192f33bf77f160c"
+  integrity sha512-a53KYv2xaJpmFlN4haI7ewaMpRqdRwaqbm11wLn0il6+LNR1/2zkRdqE3opdTW6aXNvVecNu0YQj5/u3Uz3oPw==
   dependencies:
     "@jsforce/jsforce-node" "^3.2.0"
-    "@salesforce/kit" "^3.1.1"
+    "@salesforce/kit" "^3.1.2"
     "@salesforce/schemas" "^1.9.0"
     "@salesforce/ts-types" "^2.0.9"
-    ajv "^8.13.0"
+    ajv "^8.15.0"
     change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
     faye "^1.4.0"
     form-data "^4.0.0"
     js2xmlparser "^4.0.1"
     jsonwebtoken "9.0.2"
     jszip "3.10.1"
     pino "^8.21.0"
-    pino-abstract-transport "^1.1.0"
+    pino-abstract-transport "^1.2.0"
     pino-pretty "^10.3.1"
     proper-lockfile "^4.1.2"
     semver "^7.6.2"
-    ts-retry-promise "^0.7.1"
+    ts-retry-promise "^0.8.1"
 
 "@salesforce/dev-config@^4.1.0":
   version "4.1.0"
@@ -640,12 +641,12 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^11.6.4":
-  version "11.6.4"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.6.4.tgz#9aa54f115b1f58a08a3f38d7945ce734feba824c"
-  integrity sha512-HwR33sizKJD+33Xgo7IiwnHYLXuKTwShzlr4Rv3oRBoHZyaz4wBpJOtVldwVq5l5U9++Nk5iBI4IXyWaX7SlOg==
+"@salesforce/source-deploy-retrieve@^11.6.6":
+  version "11.6.6"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-11.6.6.tgz#0bec970d04cd528f68ae9009bdd52ec1db20a6b5"
+  integrity sha512-Wf7QCYtFsBwyLAFSPPuonyUnFMIz113yabDmZd9bBEeH3dKqPFQb6zHAV3HpoU5hwvHN/+xE8QDSxv3yjtyFPw==
   dependencies:
-    "@salesforce/core" "^7.3.9"
+    "@salesforce/core" "^7.3.12"
     "@salesforce/kit" "^3.1.1"
     "@salesforce/ts-types" "^2.0.9"
     fast-levenshtein "^3.0.0"
@@ -657,15 +658,6 @@
     mime "2.6.0"
     minimatch "^5.1.6"
     proxy-agent "^6.4.0"
-
-"@salesforce/ts-sinon@^1.4.19":
-  version "1.4.19"
-  resolved "https://registry.yarnpkg.com/@salesforce/ts-sinon/-/ts-sinon-1.4.19.tgz#64157b6c8cf4a3c637867e2ddd90c2d058c334f7"
-  integrity sha512-vopxKrI6QD0OCtPlge1eGGHFWLkoDee7KaB/dpGeRwioeNfCVJ8ikELN0hv0zq9Ys6gUYWYcdpxzTP1upslCJA==
-  dependencies:
-    "@salesforce/ts-types" "^2.0.9"
-    sinon "^5.1.1"
-    tslib "^2.6.1"
 
 "@salesforce/ts-types@^2.0.9":
   version "2.0.9"
@@ -684,7 +676,7 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.4.tgz#d1f2d80f1bd0f2520873f161588bd9b7f8567120"
   integrity sha512-RpmQdHVo8hCEHDVpO39zToS9jOhR6nw+/lQAzRNq9ErrGV9IeHM71XCn68svVl/euFeVW6BWX4p35gkhbOcSIQ==
@@ -718,30 +710,6 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
-
-"@sinonjs/formatio@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
-  integrity sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==
-  dependencies:
-    samsam "1.3.0"
-
-"@sinonjs/formatio@^3.2.1":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
-  integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
-  dependencies:
-    "@sinonjs/commons" "^1"
-    "@sinonjs/samsam" "^3.1.0"
-
-"@sinonjs/samsam@^3.1.0":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
-  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
-  dependencies:
-    "@sinonjs/commons" "^1.3.0"
-    array-from "^2.1.1"
-    lodash "^4.17.15"
 
 "@sinonjs/samsam@^5.3.1":
   version "5.3.1"
@@ -1069,10 +1037,10 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.11.0, ajv@^8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.13.0.tgz#a3939eaec9fb80d217ddf0c3376948c023f28c91"
-  integrity sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==
+ajv@^8.11.0, ajv@^8.15.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.16.0.tgz#22e2a92b94f005f7e0f9c9d39652ef0b8f6f0cb4"
+  integrity sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==
   dependencies:
     fast-deep-equal "^3.1.3"
     json-schema-traverse "^1.0.0"
@@ -1167,11 +1135,6 @@ array-buffer-byte-length@^1.0.0:
   dependencies:
     call-bind "^1.0.2"
     is-array-buffer "^3.0.1"
-
-array-from@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
-  integrity sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==
 
 array-ify@^1.0.0:
   version "1.0.0"
@@ -1840,11 +1803,6 @@ diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
-
-diff@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
@@ -3659,18 +3617,6 @@ log-symbols@4.1.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-lolex@^2.4.2:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
-  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
-
-lolex@^5.0.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
-  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-
 loupe@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
@@ -3945,17 +3891,6 @@ netmask@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
-
-nise@^1.3.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.3.tgz#9d2cfe37d44f57317766c6e9408a359c5d3ac1f7"
-  integrity sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==
-  dependencies:
-    "@sinonjs/formatio" "^3.2.1"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    lolex "^5.0.1"
-    path-to-regexp "^1.7.0"
 
 nise@^4.1.0:
   version "4.1.0"
@@ -4354,7 +4289,7 @@ picomatch@^3.0.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-3.0.1.tgz#817033161def55ec9638567a2f3bbc876b3e7516"
   integrity sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==
 
-pino-abstract-transport@^1.0.0, pino-abstract-transport@^1.1.0, pino-abstract-transport@^1.2.0:
+pino-abstract-transport@^1.0.0, pino-abstract-transport@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz#97f9f2631931e242da531b5c66d3079c12c9d1b5"
   integrity sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==
@@ -4767,11 +4702,6 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
   integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
-samsam@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
-  integrity sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==
-
 sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -4932,19 +4862,6 @@ sinon@^17.0.2:
     diff "^5.2.0"
     nise "^5.1.9"
     supports-color "^7"
-
-sinon@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.1.1.tgz#19c59810ffb733ea6e76a28b94a71fc4c2f523b8"
-  integrity sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==
-  dependencies:
-    "@sinonjs/formatio" "^2.0.0"
-    diff "^3.5.0"
-    lodash.get "^4.4.2"
-    lolex "^2.4.2"
-    nise "^1.3.3"
-    supports-color "^5.4.0"
-    type-detect "^4.0.8"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -5186,7 +5103,7 @@ supports-color@8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -5299,11 +5216,6 @@ ts-node@^10.8.1, ts-node@^10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-ts-retry-promise@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ts-retry-promise/-/ts-retry-promise-0.7.1.tgz#176d6eee6415f07b6c7c286d3657355e284a6906"
-  integrity sha512-NhHOCZ2AQORvH42hOPO5UZxShlcuiRtm7P2jIq2L2RY3PBxw2mLnUsEdHrIslVBFya1v5aZmrR55lWkzo13LrQ==
-
 ts-retry-promise@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/ts-retry-promise/-/ts-retry-promise-0.8.1.tgz#ba90eb07cb03677fcbf78fe38e94c9183927e154"
@@ -5319,7 +5231,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.1, tslib@^2.0.3, tslib@^2.6.1, tslib@^2.6.2:
+tslib@^2.0.1, tslib@^2.0.3, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,23 +546,23 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@salesforce/cli-plugins-testkit@^5.3.8":
-  version "5.3.8"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.3.8.tgz#35c0d34b17e04a1162cdfa6c6450bda3f9062502"
-  integrity sha512-A+//ZlAwRPQQylIAPwo2Lob5PfSObyFbiYqYsG/ktBQlF41MASZHkCb/3/qJv1/2gPusVOUbEsmF1LRIj8reNg==
+"@salesforce/cli-plugins-testkit@^5.3.15":
+  version "5.3.15"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-5.3.15.tgz#a7e240119bbc987e869873c5a3ce3d70abbfe120"
+  integrity sha512-nst9ZKu7pqkR4Ayf3klbg4/41CmxJuLzdBL9EqGNZyZgKXBw1g+nlCcfvV9q1sY3LF2L2ljsC8N8phqiFoDKOQ==
   dependencies:
-    "@salesforce/core" "^7.3.9"
-    "@salesforce/kit" "^3.1.2"
-    "@salesforce/ts-types" "^2.0.9"
+    "@salesforce/core" "^8.0.1"
+    "@salesforce/kit" "^3.1.6"
+    "@salesforce/ts-types" "^2.0.10"
     "@types/shelljs" "^0.8.15"
-    debug "^4.3.1"
+    debug "^4.3.5"
     jszip "^3.10.1"
     shelljs "^0.8.4"
     sinon "^17.0.2"
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@8.0.1":
+"@salesforce/core@8.0.1", "@salesforce/core@^8.0.1":
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.0.1.tgz#863b527e5c60a32c2928b4d36dc070aaa159722d"
   integrity sha512-r7fmBtqy/Wjxt6RpKh+uJ30kHlHZ7Hx5Estsg2n/65nDU6nLwpXGs12OgRgObjtOv0ob/Sgh08ZQENpGXWIUJw==
@@ -587,30 +587,6 @@
     ts-retry-promise "^0.8.1"
 
 "@salesforce/core@^7.3.12":
-  version "7.3.12"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.3.12.tgz#9138980db21566c467f35afe9192f33bf77f160c"
-  integrity sha512-a53KYv2xaJpmFlN4haI7ewaMpRqdRwaqbm11wLn0il6+LNR1/2zkRdqE3opdTW6aXNvVecNu0YQj5/u3Uz3oPw==
-  dependencies:
-    "@jsforce/jsforce-node" "^3.2.0"
-    "@salesforce/kit" "^3.1.2"
-    "@salesforce/schemas" "^1.9.0"
-    "@salesforce/ts-types" "^2.0.9"
-    ajv "^8.15.0"
-    change-case "^4.1.2"
-    fast-levenshtein "^3.0.0"
-    faye "^1.4.0"
-    form-data "^4.0.0"
-    js2xmlparser "^4.0.1"
-    jsonwebtoken "9.0.2"
-    jszip "3.10.1"
-    pino "^8.21.0"
-    pino-abstract-transport "^1.2.0"
-    pino-pretty "^10.3.1"
-    proper-lockfile "^4.1.2"
-    semver "^7.6.2"
-    ts-retry-promise "^0.8.1"
-
-"@salesforce/core@^7.3.9":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-7.4.0.tgz#11c45a5f432e032bf242aaace1a175779e3e096f"
   integrity sha512-wn3fJnpG8h493qKR52Il3xgRbXg4zwbV34wonf/mTZP3n5rJeC/7S69249CGN155Os6Lds5rEUo3pGJFwgCBdQ==
@@ -639,10 +615,10 @@
   resolved "https://registry.yarnpkg.com/@salesforce/dev-config/-/dev-config-4.1.0.tgz#e529576466d074e7a5f1441236510fef123da01e"
   integrity sha512-2iDDepiIwjXHS5IVY7pwv8jMo4xWosJ7p/UTj+lllpB/gnJiYLhjJPE4Z3FCGFKyvfg5jGaimCd8Ca6bLGsCQA==
 
-"@salesforce/dev-scripts@^9.1.2":
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/dev-scripts/-/dev-scripts-9.1.2.tgz#41180b427bc4d97acd6667410f6b7642bfc000fe"
-  integrity sha512-ZVNL2j3rU+qDZ6G1nxu6pV8HFdru2L9PYL//npEmvnofwt4j8fmYiZD39K8ljLN3RxT7X1//b55R1h0DbcgeLA==
+"@salesforce/dev-scripts@^10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/dev-scripts/-/dev-scripts-10.2.0.tgz#85d7ab8b2b532d816c9a1c37a27281743c397bba"
+  integrity sha512-0Y423LwXRpJIc5fpoLSkY5zIZsQSqnhqIDkN2g93vJ28KKqwlJGdCf6qbQ6w404AbXoIhUM/xnMGY/+g6x+GEQ==
   dependencies:
     "@commitlint/cli" "^17.1.2"
     "@commitlint/config-conventional" "^17.8.1"
@@ -650,14 +626,14 @@
     "@salesforce/prettier-config" "^0.0.3"
     "@types/chai" "^4.3.14"
     "@types/mocha" "^10.0.6"
-    "@types/node" "^18.19.32"
+    "@types/node" "^18.19.34"
     "@types/sinon" "^10.0.20"
     chai "^4.3.10"
     chalk "^4.0.0"
     cosmiconfig "^8.3.6"
     eslint-config-salesforce-typescript "^3.3.0"
     husky "^7.0.4"
-    linkinator "^6.0.4"
+    linkinator "^6.0.5"
     mocha "^10.4.0"
     nyc "^15.1.0"
     prettier "^2.8.8"
@@ -666,20 +642,12 @@
     sinon "10.0.0"
     source-map-support "^0.5.21"
     ts-node "^10.9.2"
-    typedoc "^0.25.12"
+    typedoc "^0.25.13"
     typedoc-plugin-missing-exports "0.23.0"
     typescript "^5.4.3"
     wireit "^0.14.4"
 
-"@salesforce/kit@^3.1.1", "@salesforce/kit@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.2.tgz#270741c54c70969df19ef17f8979b4ef1fa664b2"
-  integrity sha512-si+ddvZDgx9q5czxAANuK5xhz3pv+KGspQy1wyia/7HDPKadA0QZkLTzUnO1Ju4Mux32CNHEb2y9lw9jj+eVTA==
-  dependencies:
-    "@salesforce/ts-types" "^2.0.9"
-    tslib "^2.6.2"
-
-"@salesforce/kit@^3.1.6":
+"@salesforce/kit@^3.1.1", "@salesforce/kit@^3.1.2", "@salesforce/kit@^3.1.6":
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.6.tgz#aefb39c0e0f325e11f80551ff92cf6979dd74070"
   integrity sha512-zAYPmCSAvdonDOnL5AzuVRVv0sRMlQd6gi12HDE1964VqSjt5pzlLU90thh3Qq4A1Wxbdu0FbHYx9BvZ4fWPvQ==
@@ -714,17 +682,10 @@
     minimatch "^5.1.6"
     proxy-agent "^6.4.0"
 
-"@salesforce/ts-types@^2.0.10":
+"@salesforce/ts-types@^2.0.10", "@salesforce/ts-types@^2.0.9":
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.10.tgz#f2107a52b60be6c3fe712f4d40aafad48c6bebe0"
   integrity sha512-ulGQ1oUGXrmSUi6NGbxZZ7ykSDv439x+WYZpkMgFLC8Dx0TxJXfUAJYeZh7eKO5xI/ob3iyvN+RBcBkp4KFN1w==
-
-"@salesforce/ts-types@^2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.9.tgz#66bff7b41720065d6b01631b6f6a3ccca02857c5"
-  integrity sha512-boUD9jw5vQpTCPCCmK/NFTWjSuuW+lsaxOynkyNXLW+zxOc4GDjhtKc4j0vWZJQvolpafbyS8ZLFHZJvs12gYA==
-  dependencies:
-    tslib "^2.6.2"
 
 "@salesforce/types@^1.1.0":
   version "1.1.0"
@@ -900,10 +861,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
 
-"@types/node@*", "@types/node@^18.15.3", "@types/node@^18.19.32":
-  version "18.19.33"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.33.tgz#98cd286a1b8a5e11aa06623210240bcc28e95c48"
-  integrity sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==
+"@types/node@*", "@types/node@^18.15.3", "@types/node@^18.19.34":
+  version "18.19.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.37.tgz#506ee89d6b5edd5a4c4e01b22162dd8309718a35"
+  integrity sha512-Pi53fdVMk7Ig5IfAMltQQMgtY7xLzHaEous8IQasYsdQbYK3v90FkxI3XYQCe/Qme58pqp14lXJIsFmGP8VoZQ==
   dependencies:
     undici-types "~5.26.4"
 
@@ -1765,7 +1726,14 @@ dateformat@^4.6.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
+  integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2182,12 +2150,12 @@ eslint-plugin-jsdoc@^46.10.1:
     semver "^7.5.4"
     spdx-expression-parse "^4.0.0"
 
-eslint-plugin-sf-plugin@^1.18.5:
-  version "1.18.5"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sf-plugin/-/eslint-plugin-sf-plugin-1.18.5.tgz#4a81063c8dea645db8be183c3257a33dc67c0158"
-  integrity sha512-yjvWM3OmxFuUUlHhDAXczo4ysX5ONoeysPL0B0Cj/zjrizvS05fjaAy53fa+AwVjOIOthWopFh2vPDSTNQ+pmA==
+eslint-plugin-sf-plugin@^1.18.8:
+  version "1.18.8"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sf-plugin/-/eslint-plugin-sf-plugin-1.18.8.tgz#e878185bf3553ab847d43f247489e4523e0c92b1"
+  integrity sha512-55bGhmI5fc7T81rESdItd3Gj2om3DN5m/tII4nblwNSXlhIqAw9zYPaWkdmCddq2N6W8UYVFGeRnw1QLYIC3/w==
   dependencies:
-    "@salesforce/core" "^7.3.9"
+    "@salesforce/core" "^8.0.1"
     "@typescript-eslint/utils" "^6.17.0"
 
 eslint-plugin-unicorn@^50.0.1:
@@ -2352,12 +2320,7 @@ extend@^3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-fast-copy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.1.tgz#9e89ef498b8c04c1cd76b33b8e14271658a732aa"
-  integrity sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==
-
-fast-copy@^3.0.2:
+fast-copy@^3.0.0, fast-copy@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.2.tgz#59c68f59ccbcac82050ba992e0d5c389097c9d35"
   integrity sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==
@@ -3549,17 +3512,17 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkinator@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/linkinator/-/linkinator-6.0.4.tgz#2a4a9f76732b0f8968abf35ed09d57a3a8be3427"
-  integrity sha512-gxZ9ePUBeoaCk29p+2gAwrRIVnKOqAV8ZVCEM8N7MvpwbccDBQiKjXFyS6nQx56K1CCZLboan2i5iJfpWCsnSQ==
+linkinator@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/linkinator/-/linkinator-6.0.5.tgz#b19344d65824d3a8beafd94c9db86ddbfb8e83aa"
+  integrity sha512-LRMHgO/29gk2WQzdj4cFcFHGKPhYPGBWVZOayATP6j3159ubonGJizObNRvgA5qDnrkqsRwJT7p4Tq97pC9GeA==
   dependencies:
     chalk "^5.0.0"
     escape-html "^1.0.3"
     gaxios "^6.0.0"
     glob "^10.3.10"
     htmlparser2 "^9.0.0"
-    marked "^10.0.0"
+    marked "^12.0.1"
     meow "^13.0.0"
     mime "^4.0.0"
     server-destroy "^1.0.1"
@@ -3745,10 +3708,10 @@ map-obj@^4.0.0:
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-marked@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-10.0.0.tgz#7fe1805bb908433d760e2de0fcc8841a2b2d745c"
-  integrity sha512-YiGcYcWj50YrwBgNzFoYhQ1hT6GmQbFG8SksnYJX1z4BXTHSOrz1GB5/Jm2yQvMg4nN1FHP4M6r03R10KrVUiA==
+marked@^12.0.1:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-12.0.2.tgz#b31578fe608b599944c69807b00f18edab84647e"
+  integrity sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==
 
 marked@^4.3.0:
   version "4.3.0"
@@ -5105,16 +5068,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5173,14 +5127,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5463,7 +5410,7 @@ typedoc-plugin-missing-exports@0.23.0:
   resolved "https://registry.yarnpkg.com/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-0.23.0.tgz#076df6ffce4d84e8097be009b7c62a17d58477a5"
   integrity sha512-9smahDSsFRno9ZwoEshQDuIYMHWGB1E6LUud5qMxR2wNZ0T4DlZz0QjoK3HzXtX34mUpTH0dYtt7NQUK4D6B6Q==
 
-typedoc@^0.25.12:
+typedoc@^0.25.13:
   version "0.25.13"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.13.tgz#9a98819e3b2d155a6d78589b46fa4c03768f0922"
   integrity sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==
@@ -5655,7 +5602,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5668,15 +5615,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,6 +655,13 @@
     "@salesforce/ts-types" "^2.0.9"
     tslib "^2.6.2"
 
+"@salesforce/kit@^3.1.6":
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-3.1.6.tgz#aefb39c0e0f325e11f80551ff92cf6979dd74070"
+  integrity sha512-zAYPmCSAvdonDOnL5AzuVRVv0sRMlQd6gi12HDE1964VqSjt5pzlLU90thh3Qq4A1Wxbdu0FbHYx9BvZ4fWPvQ==
+  dependencies:
+    "@salesforce/ts-types" "^2.0.10"
+
 "@salesforce/prettier-config@^0.0.3":
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/@salesforce/prettier-config/-/prettier-config-0.0.3.tgz#ba648d4886bb38adabe073dbea0b3a91b3753bb0"
@@ -682,6 +689,11 @@
     mime "2.6.0"
     minimatch "^5.1.6"
     proxy-agent "^6.4.0"
+
+"@salesforce/ts-types@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.10.tgz#f2107a52b60be6c3fe712f4d40aafad48c6bebe0"
+  integrity sha512-ulGQ1oUGXrmSUi6NGbxZZ7ykSDv439x+WYZpkMgFLC8Dx0TxJXfUAJYeZh7eKO5xI/ob3iyvN+RBcBkp4KFN1w==
 
 "@salesforce/ts-types@^2.0.9":
   version "2.0.9"


### PR DESCRIPTION
uses types for sfProject, PackageDir etc from sfdx-core
refactor some un-bundleable geLogger stuff
othr basic TS cleanup (remove assertions, simplify types)