### PR TITLE
feat: make `SfProject` optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       externalProjectGitUrl: 'https://github.com/salesforcecli/plugin-packaging'
       command: 'yarn test:nuts:package'
       os: ${{ matrix.os }}
-      preSwapCommands: 'yarn upgrade @salesforce/core; npx yarn-deduplicate; yarn install'
+      preSwapCommands: 'yarn upgrade @salesforce/core; yarn upgrade @jsforce/jsforce-node@latest; npx yarn-deduplicate; yarn install'
       preExternalBuildCommands: 'npm why @salesforce/core --json'
       useCache: false
     secrets: inherit

--- a/messages/package_version.md
+++ b/messages/package_version.md
@@ -6,9 +6,17 @@ The %s %s is invalid, as a corresponding %s was not found
 
 The provided alias or ID: [%s] could not be resolved to a valid package version ID (05i) or subscriber package version ID (04t).
 
+# errorInvalidPackageVersionIdNoProject
+
+The provided alias or ID: [%s] could not be resolved to a valid package version ID (05i) or subscriber package version ID (04t).
+
+# errorInvalidPackageVersionIdNoProject.actions
+
+If you are using a package alias, make sure you are inside your sfdx project and it's defined in the `packageDirectories` section in `sfdx-project.json`
+
 # packageAliasNotFound
 
-The provided package id: [%s] could not be resolved to an alias.
+The provided package ID: [%s] could not be resolved to an alias.
 
 # createResultIdCannotBeEmpty
 

--- a/messages/package_version.md
+++ b/messages/package_version.md
@@ -21,3 +21,9 @@ Could not fetch the subscriber package version ID (04t).
 # maxPackage2VersionRecords
 
 The maximum result size (2000) was reached when querying the Package2Version SObject. This means there could be more records that were not returned by the query. If all records are required you may have to break the query into multiple requests filtered by date, then aggregate the results.
+
+# errors.RequiresProject
+
+This method expects an sfdx project to be available to write the new package version data in it.
+Make sure to pass `options.project` when instantiating `PackageVersion`.
+https://forcedotcom.github.io/packaging/classes/package_packageVersion.PackageVersion.html#constructor

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.4.1",
-    "@salesforce/core": "^8.3.0",
+    "@salesforce/core": "^8.4.0",
     "@salesforce/kit": "^3.2.1",
     "@salesforce/schemas": "^1.9.0",
-    "@salesforce/source-deploy-retrieve": "^12.1.12",
+    "@salesforce/source-deploy-retrieve": "^12.4.0",
     "@salesforce/ts-types": "^2.0.11",
     "@salesforce/types": "^1.2.0",
     "fast-xml-parser": "^4.4.1",
@@ -61,7 +61,7 @@
     "@salesforce/dev-scripts": "^10.2.9",
     "@types/globby": "^9.1.0",
     "@types/jszip": "^3.4.1",
-    "eslint-plugin-sf-plugin": "^1.20.1",
+    "eslint-plugin-sf-plugin": "^1.20.4",
     "shelljs": "0.8.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/packaging",
-  "version": "4.1.14-dev.2",
+  "version": "4.1.13",
   "description": "Packaging library for the Salesforce packaging platform",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.4.1",
-    "@salesforce/core": "^8.2.9",
+    "@salesforce/core": "^8.3.0",
     "@salesforce/kit": "^3.2.0",
     "@salesforce/schemas": "^1.9.0",
     "@salesforce/source-deploy-retrieve": "^12.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/packaging",
-  "version": "4.1.14-dev.0",
+  "version": "4.1.14-dev.1",
   "description": "Packaging library for the Salesforce packaging platform",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.4.1",
-    "@salesforce/core": "^8.2.8",
+    "@salesforce/core": "^8.2.9",
     "@salesforce/kit": "^3.2.0",
     "@salesforce/schemas": "^1.9.0",
     "@salesforce/source-deploy-retrieve": "^12.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/packaging",
-  "version": "4.1.13",
+  "version": "4.1.14-dev.0",
   "description": "Packaging library for the Salesforce packaging platform",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/packaging",
-  "version": "4.1.14-dev.1",
+  "version": "4.1.14-dev.2",
   "description": "Packaging library for the Salesforce packaging platform",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -42,7 +42,7 @@ export type IPackageVersion2GP = {
 
 export type PackageOptions = {
   connection: Connection;
-  project: SfProject;
+  project?: SfProject;
   packageAliasOrId: string;
 };
 
@@ -288,7 +288,7 @@ export type PackageVersionOptions = {
    * 3. Alias for a 04t or 05i, defined in sfdx-project.json
    */
   idOrAlias: string;
-  project: SfProject;
+  project?: SfProject;
 };
 
 export type SubscriberPackageVersionOptions = {
@@ -431,7 +431,7 @@ export type PackageAncestryNodeData = {
 
 export type PackageAncestryOptions = {
   packageId: string;
-  project: SfProject;
+  project?: SfProject;
   connection: Connection;
 };
 

--- a/src/package/package.ts
+++ b/src/package/package.ts
@@ -83,8 +83,9 @@ export class Package {
   public constructor(private options: PackageOptions) {
     let packageId = this.options.packageAliasOrId;
     if (!packageId.startsWith(packagePrefixes.PackageId)) {
-      packageId =
-        this.options.project.getPackageIdFromAlias(this.options.packageAliasOrId) ?? this.options.packageAliasOrId;
+      packageId = this.options.project
+        ? this.options.project.getPackageIdFromAlias(this.options.packageAliasOrId) ?? this.options.packageAliasOrId
+        : this.options.packageAliasOrId;
       if (packageId === this.options.packageAliasOrId) {
         throw messages.createError('packageAliasNotFound', [this.options.packageAliasOrId]);
       }
@@ -136,12 +137,12 @@ export class Package {
    */
   public static async listVersions(
     connection: Connection,
-    project: SfProject,
+    project?: SfProject,
     options?: PackageVersionListOptions
   ): Promise<PackageVersionListResult[]> {
     // resolve/verify packages
     const packages = options?.packages?.map((pkg) => {
-      const id = project.getPackageIdFromAlias(pkg) ?? pkg;
+      const id = project ? project.getPackageIdFromAlias(pkg) ?? pkg : pkg;
 
       // validate ID
       if (id.startsWith('0Ho')) {
@@ -166,7 +167,7 @@ export class Package {
    */
   public static async getAncestry(
     packageId: string,
-    project: SfProject,
+    project: SfProject | undefined,
     connection: Connection
   ): Promise<PackageAncestry> {
     return PackageAncestry.create({

--- a/src/package/packageAncestry.ts
+++ b/src/package/packageAncestry.ts
@@ -231,7 +231,9 @@ export class PackageAncestry extends AsyncCreatable<PackageAncestryOptions> {
 
   private async getRootsFromRequestedId(): Promise<PackageAncestryNode[]> {
     let roots: PackageAncestryNode[] = [];
-    this.packageId = this.options.project.getPackageIdFromAlias(this.options.packageId) ?? this.options.packageId;
+    this.packageId = this.options.project
+      ? this.options.project.getPackageIdFromAlias(this.options.packageId) ?? this.options.packageId
+      : this.options.packageId;
     switch (this.requestedPackageId?.slice(0, 3)) {
       case '0Ho':
         pkgUtils.validateId(pkgUtils.BY_LABEL.PACKAGE_ID, this.requestedPackageId);

--- a/src/package/packageDelete.ts
+++ b/src/package/packageDelete.ts
@@ -11,11 +11,11 @@ import { PackageSaveResult } from '../interfaces';
 
 export async function deletePackage(
   idOrAlias: string,
-  project: SfProject,
+  project: SfProject | undefined,
   connection: Connection,
   undelete: boolean
 ): Promise<PackageSaveResult> {
-  const packageId = project.getPackageIdFromAlias(idOrAlias) ?? idOrAlias;
+  const packageId = project ? project.getPackageIdFromAlias(idOrAlias) ?? idOrAlias : idOrAlias;
   validateId(BY_LABEL.PACKAGE_ID, packageId);
 
   const request = { Id: packageId, IsDeprecated: !undelete };

--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -117,7 +117,7 @@ export type Package2VersionQueryOptions = {
  * `new PackageVersion({connection, project, idOrAlias}).promote();`
  */
 export class PackageVersion {
-  private readonly project: SfProject;
+  private readonly project?: SfProject;
   private readonly connection: Connection;
 
   private data?: Package2Version;
@@ -619,6 +619,9 @@ export class PackageVersion {
   }
 
   private async updateProjectWithPackageVersion(results: PackageVersionCreateRequestResult): Promise<void> {
+    if (!this.project) {
+      throw new Error('AN SFDX PROJECT IS REQUIRED!');
+    }
     if (!env.getBoolean('SF_PROJECT_AUTOUPDATE_DISABLE_FOR_PACKAGE_VERSION_CREATE')) {
       // get the newly created package version from the server
       const versionResult = (
@@ -659,6 +662,8 @@ export class PackageVersion {
   }
 
   private resolveId(): string {
-    return this.project.getPackageIdFromAlias(this.options.idOrAlias) ?? this.options.idOrAlias;
+    return this.project
+      ? this.project.getPackageIdFromAlias(this.options.idOrAlias) ?? this.options.idOrAlias
+      : this.options.idOrAlias;
   }
 }

--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -620,7 +620,7 @@ export class PackageVersion {
 
   private async updateProjectWithPackageVersion(results: PackageVersionCreateRequestResult): Promise<void> {
     if (!this.project) {
-      throw new Error('AN SFDX PROJECT IS REQUIRED!');
+      throw new SfError('errors.RequiresProject');
     }
     if (!env.getBoolean('SF_PROJECT_AUTOUPDATE_DISABLE_FOR_PACKAGE_VERSION_CREATE')) {
       // get the newly created package version from the server

--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -662,8 +662,26 @@ export class PackageVersion {
   }
 
   private resolveId(): string {
-    return this.project
-      ? this.project.getPackageIdFromAlias(this.options.idOrAlias) ?? this.options.idOrAlias
-      : this.options.idOrAlias;
+    let packageId = this.options.idOrAlias;
+
+    if (packageId.startsWith('04t') || packageId.startsWith('05i')) {
+      return packageId;
+    }
+
+    if (!this.options.project) {
+      throw messages.createError('errorInvalidPackageVersionIdNoProject', [this.options.idOrAlias]);
+    }
+
+    packageId = this.options.project.getPackageIdFromAlias(this.options.idOrAlias) ?? this.options.idOrAlias;
+
+    if (packageId === this.options.idOrAlias) {
+      throw messages.createError('packageAliasNotFound', [this.options.idOrAlias]);
+    }
+    // validate the resolved alias value from sfdx-project is a valid ID
+    if (packageId.startsWith('04t') || packageId.startsWith('05i')) {
+      return packageId;
+    } else {
+      throw messages.createError('errorInvalidPackageVersionId', [this.options.idOrAlias]);
+    }
   }
 }

--- a/src/package/packageVersionReport.ts
+++ b/src/package/packageVersionReport.ts
@@ -74,7 +74,7 @@ function constructQuery(connectionVersion: number, verbose: boolean): string {
 export async function getPackageVersionReport(options: {
   packageVersionId: string;
   connection: Connection;
-  project: SfProject;
+  project?: SfProject;
   verbose: boolean;
 }): Promise<PackageVersionReportResult[]> {
   getLogger().debug(`entering getPackageVersionReport(${util.inspect(options, { depth: null })})`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,10 +523,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.2.3", "@salesforce/core@^8.2.8", "@salesforce/core@^8.2.9":
-  version "8.2.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.2.9.tgz#076d08af5e953ae20ac247f2a2601e18ffce13c8"
-  integrity sha512-LRBv3XJtmZc/zMmxgHgefmrafRzJi+9Zp1hdazpEXOuxi5IK6vdUWSrwNCkTbYUEyZlD6XdC467jK/A2x7T1sQ==
+"@salesforce/core@^8.2.3", "@salesforce/core@^8.2.8", "@salesforce/core@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.3.0.tgz#b61fb6c0c0dec5664ce12ba62ebe35136ae33878"
+  integrity sha512-HZchC42oGJ5RQsG9HpAb1bT7ohjB31ATDz46ryMvLngMmrfHnyzv2mlIi6UdYkJ/2meH2BJkibHi8paPrtF+/A==
   dependencies:
     "@jsforce/jsforce-node" "^3.4.0"
     "@salesforce/kit" "^3.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,10 +523,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.2.3", "@salesforce/core@^8.2.8", "@salesforce/core@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.3.0.tgz#b61fb6c0c0dec5664ce12ba62ebe35136ae33878"
-  integrity sha512-HZchC42oGJ5RQsG9HpAb1bT7ohjB31ATDz46ryMvLngMmrfHnyzv2mlIi6UdYkJ/2meH2BJkibHi8paPrtF+/A==
+"@salesforce/core@^8.2.3", "@salesforce/core@^8.3.0", "@salesforce/core@^8.4.0":
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.4.0.tgz#d2ddfe07994c42b1e917e581e9cf47ad27b97a93"
+  integrity sha512-P+n0+Sp+v6voLTShW2E5sdF7gCUxEXJjNcc9Jtto0ZMyQesmQJ6WGpWmAuRoi+BVYc8OPSlEffndaYDAo/u73g==
   dependencies:
     "@jsforce/jsforce-node" "^3.4.0"
     "@salesforce/kit" "^3.1.6"
@@ -601,13 +601,13 @@
   resolved "https://registry.yarnpkg.com/@salesforce/schemas/-/schemas-1.9.0.tgz#ba477a112653a20b4edcf989c61c57bdff9aa3ca"
   integrity sha512-LiN37zG5ODT6z70sL1fxF7BQwtCX9JOWofSU8iliSNIM+WDEeinnoFtVqPInRSNt8I0RiJxIKCrqstsmQRBNvA==
 
-"@salesforce/source-deploy-retrieve@^12.1.12":
-  version "12.1.12"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.1.12.tgz#1a8b1cc54daa16ecb8c5abbbbb67c3bd367d8a41"
-  integrity sha512-+Kbc62eB4epGBB6rr+EXzrSTmtBOXD1RNc5AIhnhnYSwL+WNIln5GOAmtZWVa/YOihjc1jTQF1/uHG4dKGCG9w==
+"@salesforce/source-deploy-retrieve@^12.4.0":
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.4.0.tgz#7e5a72b1d7b559eaa7f6f333ee212380b6316542"
+  integrity sha512-gvTEjLPbNRt62GEKvejt/f1TtG6Zx8JPd/5BYjnXyEJu8BeOy5kL4zJm9GD3ZiTzBnPGHLzfVL09JjWfNBbo0A==
   dependencies:
-    "@salesforce/core" "^8.2.8"
-    "@salesforce/kit" "^3.1.6"
+    "@salesforce/core" "^8.4.0"
+    "@salesforce/kit" "^3.2.1"
     "@salesforce/ts-types" "^2.0.12"
     fast-levenshtein "^3.0.0"
     fast-xml-parser "^4.4.1"
@@ -966,7 +966,7 @@
     "@typescript-eslint/typescript-estree" "6.21.0"
     semver "^7.5.4"
 
-"@typescript-eslint/utils@^7.17.0":
+"@typescript-eslint/utils@^7.18.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-7.18.0.tgz#bca01cde77f95fc6a8d5b0dbcbfb3d6ca4be451f"
   integrity sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==
@@ -2151,13 +2151,13 @@ eslint-plugin-jsdoc@^46.10.1:
     semver "^7.5.4"
     spdx-expression-parse "^4.0.0"
 
-eslint-plugin-sf-plugin@^1.20.1:
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sf-plugin/-/eslint-plugin-sf-plugin-1.20.1.tgz#bdde7cd6b62df1f707770273768a4fecdf901cfa"
-  integrity sha512-Mf4gC4I87h+coOpwh2uIRbhCzTGDGX7QskLGzst7fktzXkCwsIXMVic6NHPWSWIA6U8IU4g5MwMiZjuXqJTwdA==
+eslint-plugin-sf-plugin@^1.20.4:
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sf-plugin/-/eslint-plugin-sf-plugin-1.20.4.tgz#9d99f76cd316939222231f74bb65fc76ddd7fee4"
+  integrity sha512-lpuF4XGVenrQotd0cUZhgZ4rLDubytWPJBzmMCIovZdqyGYzgD68MGofDSLFzmbhKfa2fX1Pndljru6/GjVyGQ==
   dependencies:
-    "@salesforce/core" "^8.2.3"
-    "@typescript-eslint/utils" "^7.17.0"
+    "@salesforce/core" "^8.3.0"
+    "@typescript-eslint/utils" "^7.18.0"
 
 eslint-plugin-unicorn@^50.0.1:
   version "50.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,10 +523,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.2.3", "@salesforce/core@^8.2.8":
-  version "8.2.8"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.2.8.tgz#1e93ddd8b9f348f1e20547de4cdff30062520fd9"
-  integrity sha512-Fyy1TG9cUtQV+YAjyYCHerZ0K/t9fuB6dU9HrXFvcjMKorMS5JaI1wkZh8w1+zfvu6GY/MOzeqVZCq2W+9ShLA==
+"@salesforce/core@^8.2.3", "@salesforce/core@^8.2.8", "@salesforce/core@^8.2.9":
+  version "8.2.9"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.2.9.tgz#076d08af5e953ae20ac247f2a2601e18ffce13c8"
+  integrity sha512-LRBv3XJtmZc/zMmxgHgefmrafRzJi+9Zp1hdazpEXOuxi5IK6vdUWSrwNCkTbYUEyZlD6XdC467jK/A2x7T1sQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.4.0"
     "@salesforce/kit" "^3.1.6"
@@ -5048,16 +5048,7 @@ srcset@^5.0.0:
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-5.0.0.tgz#9df6c3961b5b44a02532ce6ae4544832609e2e3f"
   integrity sha512-SqEZaAEhe0A6ETEa9O1IhSPC7MdvehZtCnTR0AftXk3QhY2UNgb+NApFOUPZILXk/YTDfFxMTNJOBpzrJsEdIA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5116,14 +5107,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5589,7 +5573,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5602,15 +5586,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR updates some packaging classes to make `SfProject` optional.

See: https://github.com/salesforcecli/plugin-packaging/pull/771

Most of these classes were taking an `SfProject` instance along with a possible package ID **or** alias (defined in sfdx-project.json). By making `SfProject` optional, consumers of the library can call it without having to create a dummy sfdx-project.

Note for review:
there are classes/methods that do need a project b/c they write stuff on it after a package operation, most of these aren't affected by this change (`PackageVersion.updateProjectWithPackageVersion` was updated to throw if there's no project).

QA:

Check the plugin-packaging PR linked above, with this branch linked (or the prerelease) you should be able to use the listed commands outside a project.

@W-16286213@