### PR TITLE
add totalnumberofmetadatafiles field

### DIFF
--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -80,6 +80,7 @@ export type PackageVersionCreateRequestResult = {
   VersionNumber: string | null;
   CreatedBy: string;
   ConvertedFromVersionId: string | null;
+  TotalNumberOfMetadataFiles: number | null;
 };
 
 export const PackageVersionCreateRequestResultInProgressStatuses = Object.values(Package2VersionStatus).filter(

--- a/src/interfaces/packagingSObjects.ts
+++ b/src/interfaces/packagingSObjects.ts
@@ -62,6 +62,7 @@ export namespace PackagingSObjects {
     HasMetadataRemoved: boolean;
     Language: string;
     EndToEndBuildDurationInSeconds?: number;
+    TotalNumberOfMetadataFiles: number;
   };
 
   export enum Package2VersionStatus {

--- a/src/package/packageVersionCreateRequest.ts
+++ b/src/package/packageVersionCreateRequest.ts
@@ -24,7 +24,7 @@ export function getQuery(connection: Connection): string {
     'SELECT Id, Status, Package2Id, Package2.Name, Package2VersionId, Package2Version.SubscriberPackageVersionId, Package2Version.HasPassedCodeCoverageCheck,Package2Version.CodeCoverage, Tag, Branch, ' +
     'Package2Version.MajorVersion, Package2Version.MinorVersion, Package2Version.PatchVersion, Package2Version.BuildNumber, ' +
     'CreatedDate, Package2Version.HasMetadataRemoved, CreatedById, IsConversionRequest, Package2Version.ConvertedFromVersionId ' +
-    (Number(connection.version) > 60.0 ? ', AsyncValidation ' : '') +
+    (Number(connection.version) > 60.0 ? ', AsyncValidation, Package2Version.TotalNumberOfMetadataFiles ' : '') +
     'FROM Package2VersionCreateRequest ' +
     '%s' + // WHERE, if applicable
     'ORDER BY CreatedDate desc';
@@ -84,6 +84,7 @@ async function query(query: string, connection: Connection): Promise<PackageVers
         | 'MinorVersion'
         | 'PatchVersion'
         | 'BuildNumber'
+        | 'TotalNumberOfMetadataFiles'
       >;
     } & {
       Package2: Pick<PackagingSObjects.Package2, 'Name'>;
@@ -114,6 +115,8 @@ async function query(query: string, connection: Connection): Promise<PackageVers
       record.Package2Version != null ? record.Package2Version.HasPassedCodeCoverageCheck : null,
     CreatedBy: record.CreatedById,
     ConvertedFromVersionId: convertedFromVersionMessage(record.Status, record.Package2Version?.ConvertedFromVersionId),
+    TotalNumberOfMetadataFiles:
+      record.Package2Version != null ? record.Package2Version.TotalNumberOfMetadataFiles : null,
   }));
 }
 

--- a/src/package/packageVersionReport.ts
+++ b/src/package/packageVersionReport.ts
@@ -40,8 +40,8 @@ const defaultFields = [
 
 let verboseFields = ['SubscriberPackageVersion.Dependencies', 'CodeCoveragePercentages'];
 
-// Ensure we only include the async validation property for api version of v60.0 or higher.
-const default61Fields = ['ValidatedAsync'];
+// Add Fields here that are only available for api versions higher than v60.0
+const default61Fields = ['ValidatedAsync', 'TotalNumberOfMetadataFiles'];
 
 const verbose61Fields = ['EndToEndBuildDurationInSeconds'];
 

--- a/test/package/packageConvert.test.ts
+++ b/test/package/packageConvert.test.ts
@@ -247,6 +247,7 @@ describe('packageConvert', () => {
       Status: 'Success',
       SubscriberPackageVersionId: null,
       Tag: 'tag',
+      TotalNumberOfMetadataFiles: null,
     };
 
     Lifecycle.getInstance().on(PackageEvents.convert.progress, async (data) => {

--- a/test/package/packageConvert.test.ts
+++ b/test/package/packageConvert.test.ts
@@ -272,6 +272,7 @@ describe('packageConvert', () => {
           Status: 'inProgress',
           SubscriberPackageVersionId: null,
           Tag: undefined,
+          TotalNumberOfMetadataFiles: null,
         },
         timeRemaining: {
           quantity: 2,

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -42,6 +42,7 @@ describe('Package Version Create', () => {
     'SubscriberPackageVersionId',
     'Tag',
     'VersionNumber',
+    'TotalNumberOfMetadataFiles',
   ];
 
   const $$ = instantiateContext();


### PR DESCRIPTION
- Added TotalNumberOfMetadataFiles as queryable field only for api version > 60
- Added TotalNumberOfMetadataFiles field as part of PackageVersionReportResult and PackageVersionCreateRequestResult.
- PackageVersionCreateRequestResult is queried on package version creation status. On success , TotalNumberOfMetadataFiles will be used to log warning if it exceeds predefined limit(This will be added in plugin-packaging)

