### PR TITLE
W-18561384: when the conversion CLI command times out, provide a meaningful …

### DIFF
--- a/src/package/packageConvert.ts
+++ b/src/package/packageConvert.ts
@@ -129,15 +129,27 @@ export async function convertPackage(
 
   let results: Many<PackageVersionCreateRequestResult>;
   if (options.wait) {
-    results = await pollForStatusWithInterval(
-      createResult.id,
-      maxRetries,
-      packageId,
-      branch,
-      project,
-      connection,
-      options.frequency ?? Duration.seconds(POLL_INTERVAL_SECONDS)
-    );
+    try {
+      results = await pollForStatusWithInterval(
+        createResult.id,
+        maxRetries,
+        packageId,
+        branch,
+        project,
+        connection,
+        options.frequency ?? Duration.seconds(POLL_INTERVAL_SECONDS)
+      );
+    } catch (e) {
+      if (e instanceof SfError) {
+        const err = e as SfError;
+        if (err.name === 'PollingClientTimeout') {
+          err.setData({ VersionCreateRequestId: createResult.id });
+          err.message += ` Run 'sf package version create report -i ${createResult.id}' to check the status.`;
+        }
+        throw pkgUtils.applyErrorAction(pkgUtils.massageErrorMessage(e));
+      }
+      throw e;
+    }
   } else {
     results = await byId(packageId, connection);
   }

--- a/src/package/packageConvert.ts
+++ b/src/package/packageConvert.ts
@@ -146,7 +146,7 @@ export async function convertPackage(
           err.setData({ VersionCreateRequestId: createResult.id });
           err.message += ` Run 'sf package version create report -i ${createResult.id}' to check the status.`;
         }
-        throw pkgUtils.applyErrorAction(pkgUtils.massageErrorMessage(e));
+        throw pkgUtils.applyErrorAction(pkgUtils.massageErrorMessage(err));
       }
       throw e;
     }


### PR DESCRIPTION
…response

What does this PR do?

Provides a meaningful response message when the "sf package convert" command gets a PollingClientTimeout error.
e.g. The client has timed out. Run 'sf package version create report -i 08cxx0000004FZwAAM' to check the status.

What issues does this PR fix or reference?

@W-18561384@ When the conversion CLI command times out, it does not provide any meaningful response.