### PR TITLE
W-17369132: feat: ignore DeveloperUsePkgZip for id retrieve

### DIFF
--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -501,7 +501,10 @@ export class PackageVersion {
             label2: BY_LABEL.PACKAGE_VERSION_ID.label,
           };
 
-      const allFields = PackageVersion.getPackage2VersionFields(this.connection).toString();
+      let allFieldsArr = PackageVersion.getPackage2VersionFields(this.connection);
+      // Remove DeveloperUsePkgZip because the user may not have the DownloadPackageVersionZips user permission
+      allFieldsArr = allFieldsArr.filter((field) => field !== 'DeveloperUsePkgZip');
+      const allFields = allFieldsArr.toString();
       const query = `SELECT ${allFields} FROM Package2Version WHERE ${queryConfig.clause} LIMIT 1`;
       try {
         this.data = await this.connection.singleRecordQuery<Package2Version>(query, { tooling: true });


### PR DESCRIPTION
@W-17369132@

This fixes an issue with the addition of DeveloperUsePkgZip to the Package2VersionFields. That field is not visible unless the user has been assigned the DownloadPackageVersionZips user permission. The field is only need for doing a package version retrieve, so filter it out for other use cases so it doesn't cause failures in other commands if the user perm is not granted to the user.