### PR TITLE
@ W-22495755@ [CLI] Improve Error Message When Package Version Retrieve Fails Due to Dev Zip Not Generated

### DIFF
--- a/messages/package.md
+++ b/messages/package.md
@@ -38,9 +38,13 @@ Can't retrieve package version metadata. The specified directory must be relativ
 
 Can't retrieve package metadata. To use this feature, you must first assign yourself the DownloadPackageVersionZips user permission. Then retry retrieving your package metadata.
 
-# downloadDeveloperPackageZipHasNoData
+# downloadDeveloperPackageZipHasNoDataNative2GP
 
-Can't retrieve package metadata. Package metadata is only generated for converted 2GP package versions and versions created with the --generate-pkg-zip flag. To resolve, create a new package version and retry. For native 2GP packages, include the --generate-pkg-zip flag when creating the version. For 1GP packages, first convert them to 2GP.
+Can't retrieve package metadata. The developer package zip for this native 2GP package version is unretrievable. To resolve, create a new package version with the --generate-pkg-zip flag. Then retry retrieving your package metadata.
+
+# downloadDeveloperPackageZipHasNoDataConverted2GP
+
+Can't retrieve package metadata. The developer package zip for this converted 2GP package version is unretrievable. To resolve, retry conversion to produce a new converted package version. Then retry retrieving your package metadata.
 
 # packagingNotEnabledOnOrg
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.10.14",
-    "@salesforce/core": "^8.29.0",
+    "@salesforce/core": "^8.31.0",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/schemas": "^1.10.3",
     "@salesforce/source-deploy-retrieve": "^12.35.0",

--- a/src/package/packageVersionRetrieve.ts
+++ b/src/package/packageVersionRetrieve.ts
@@ -92,7 +92,10 @@ export async function retrievePackageVersionMetadata(
     tree = await ZipTreeContainer.create(buffer);
   } catch (e) {
     if (e instanceof Error && e.message.includes('data length = 0')) {
-      throw messages.createError('downloadDeveloperPackageZipHasNoData');
+      const messageKey = versionInfo.ConvertedFromVersionId
+        ? 'downloadDeveloperPackageZipHasNoDataConverted2GP'
+        : 'downloadDeveloperPackageZipHasNoDataNative2GP';
+      throw messages.createError(messageKey);
     }
     throw e;
   }

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -19,6 +19,7 @@ import * as sinon from 'sinon';
 import { instantiateContext, MockTestOrgData, restoreContext, stubContext } from '@salesforce/core/testSetup';
 import { assert, expect } from 'chai';
 import { Connection, SfProject, SfError } from '@salesforce/core';
+import { ZipTreeContainer } from '@salesforce/source-deploy-retrieve';
 import * as packageUtils from '../../src/utils/packageUtils';
 import { Package } from '../../src/package/package';
 import { PackageVersion } from '../../src/package/packageVersion';
@@ -318,6 +319,42 @@ describe('Package Version Retrieve', () => {
       expect(error.message).to.equal(
         "Can't retrieve package version metadata. The specified directory must be relative to your Salesforce DX project directory, and not an absolute path."
       );
+    }
+  });
+
+  it('should throw the native-2GP "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is unset', async () => {
+    $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
+    queryPackage2VersionStub
+      .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
+      .resolves([{ ...mockPackage2Version, ConvertedFromVersionId: '' }]);
+
+    try {
+      await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);
+      assert.fail('Expected test execution to raise an error');
+    } catch (e) {
+      const error = e as SfError;
+      expect(error.message).to.include('native 2GP package version is unretrievable');
+      expect(error.message).to.include('--generate-pkg-zip');
+      expect(error.message).to.include('Then retry retrieving your package metadata');
+      expect(error.message).to.not.include('converted');
+    }
+  });
+
+  it('should throw the converted-2GP "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is set', async () => {
+    $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
+    queryPackage2VersionStub
+      .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
+      .resolves([{ ...mockPackage2Version, ConvertedFromVersionId: '05ixx0000000conv' }]);
+
+    try {
+      await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);
+      assert.fail('Expected test execution to raise an error');
+    } catch (e) {
+      const error = e as SfError;
+      expect(error.message).to.include('converted 2GP package version is unretrievable');
+      expect(error.message).to.include('retry conversion to produce a new converted package version');
+      expect(error.message).to.not.include('--generate-pkg-zip');
+      expect(error.message).to.not.include('native');
     }
   });
 

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -344,7 +344,7 @@ describe('Package Version Retrieve', () => {
     $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
     queryPackage2VersionStub
       .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
-      .resolves([{ ...mockPackage2Version, ConvertedFromVersionId: '05ixx0000000conv' }]);
+      .resolves([{ ...mockPackage2Version, ConvertedFromVersionId: '04txx0000004HwAAAU' }]);
 
     try {
       await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,7 +578,7 @@
 
 "@salesforce/core@^8.31.0":
   version "8.31.0"
-  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@salesforce/core/-/core-8.31.0.tgz#153beb193af8fce73d31cc39afee794c4c1ee1c0"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.0.tgz#153beb193af8fce73d31cc39afee794c4c1ee1c0"
   integrity sha512-TXQoR7Bs0Dk5AuNY8eaNRhMeLDLcpJ8su7LVxn7VVfnRxITrRh4gkSuOAXdBKAqx0WcjRONDs1twedaOE7Xu4Q==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.13"
@@ -2739,7 +2739,7 @@ form-data@^4.0.4:
 
 form-data@^4.0.5:
   version "4.0.5"
-  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
@@ -5273,7 +5273,7 @@ semver@^7.3.4, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.3:
 
 semver@^7.8.0:
   version "7.8.1"
-  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
   integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
 
 sentence-case@^3.0.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -551,7 +551,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.23.1", "@salesforce/core@^8.28.4", "@salesforce/core@^8.29.0", "@salesforce/core@^8.29.1":
+"@salesforce/core@^8.23.1", "@salesforce/core@^8.28.4", "@salesforce/core@^8.29.1":
   version "8.30.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.30.1.tgz#870f81cd46967614f3842314eb51ce46548eb6a0"
   integrity sha512-2TBt9r7Ci5bc/cq3MbS9NssvdsnXOF76d/6EElimgdqTcgFnsHdD8u5j+TVE+ivGaFnpIGAWZ7Xvmes2qys2cw==
@@ -573,6 +573,31 @@
     pino-pretty "^11.3.0"
     proper-lockfile "^4.1.2"
     semver "^7.7.3"
+    ts-retry-promise "^0.8.1"
+    zod "^4.1.12"
+
+"@salesforce/core@^8.31.0":
+  version "8.31.0"
+  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@salesforce/core/-/core-8.31.0.tgz#153beb193af8fce73d31cc39afee794c4c1ee1c0"
+  integrity sha512-TXQoR7Bs0Dk5AuNY8eaNRhMeLDLcpJ8su7LVxn7VVfnRxITrRh4gkSuOAXdBKAqx0WcjRONDs1twedaOE7Xu4Q==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.10.13"
+    "@salesforce/kit" "^3.2.4"
+    "@salesforce/ts-types" "^2.0.12"
+    ajv "^8.18.0"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.1"
+    form-data "^4.0.5"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.3"
+    jszip "3.10.1"
+    memfs "4.38.1"
+    pino "^9.7.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.3.0"
+    proper-lockfile "^4.1.2"
+    semver "^7.8.0"
     ts-retry-promise "^0.8.1"
     zod "^4.1.12"
 
@@ -2705,6 +2730,17 @@ form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -5234,6 +5270,11 @@ semver@^7.3.4, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
+
+semver@^7.8.0:
+  version "7.8.1"
+  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
+  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
 
 sentence-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
This PR updates the error message that users receive when the developer zip failed to generate during conversion, and when the user tries to retrieve a dev zip for a native 2GP version for which there's no dev zip generated. Previously, the message was too long, and it misled users who saw dev zip generation failures during conversion because it did not tell users specifically to retry conversion. To make it clear, we split the long message into two distinct messages: one for converted 2GP package versions and one for native 2GP package versions. Each method includes specific, actionable remedies for the user. See [@W-22495755@](https://gus.lightning.force.com/lightning/_classic/%2Fa07EE00002a2ka3YAA)