### PR TITLE
W-22570931: [TEMP] Improve Error Message When Package Version Retrieve Fails Due to Dev Zip Not Generated

### DIFF
--- a/messages/package.md
+++ b/messages/package.md
@@ -38,13 +38,9 @@ Can't retrieve package version metadata. The specified directory must be relativ
 
 Can't retrieve package metadata. To use this feature, you must first assign yourself the DownloadPackageVersionZips user permission. Then retry retrieving your package metadata.
 
-# downloadDeveloperPackageZipHasNoDataNative2GP
+# downloadDeveloperPackageZipHasNoData
 
-Can't retrieve package metadata. The developer package zip for this native 2GP package version is unretrievable. To resolve, create a new package version with the --generate-pkg-zip flag. Then retry retrieving your package metadata.
-
-# downloadDeveloperPackageZipHasNoDataConverted2GP
-
-Can't retrieve package metadata. The developer package zip for this converted 2GP package version is unretrievable. To resolve, retry conversion to produce a new converted package version. Then retry retrieving your package metadata.
+Can't retrieve package metadata. Package metadata is only generated for converted 2GP package versions and versions created with the --generate-pkg-zip flag. To resolve, create a new package version and retry. For native 2GP packages, include the --generate-pkg-zip flag when creating the version. For 1GP packages, first convert them to 2GP.
 
 # packagingNotEnabledOnOrg
 

--- a/src/package/packageVersionRetrieve.ts
+++ b/src/package/packageVersionRetrieve.ts
@@ -92,10 +92,7 @@ export async function retrievePackageVersionMetadata(
     tree = await ZipTreeContainer.create(buffer);
   } catch (e) {
     if (e instanceof Error && e.message.includes('data length = 0')) {
-      const messageKey = versionInfo.ConvertedFromVersionId
-        ? 'downloadDeveloperPackageZipHasNoDataConverted2GP'
-        : 'downloadDeveloperPackageZipHasNoDataNative2GP';
-      throw messages.createError(messageKey);
+      throw messages.createError('downloadDeveloperPackageZipHasNoData');
     }
     throw e;
   }

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -322,7 +322,7 @@ describe('Package Version Retrieve', () => {
     }
   });
 
-  it('should throw the native-2GP "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is unset', async () => {
+  it('should throw the unified "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is unset', async () => {
     $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
     queryPackage2VersionStub
       .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
@@ -333,14 +333,14 @@ describe('Package Version Retrieve', () => {
       assert.fail('Expected test execution to raise an error');
     } catch (e) {
       const error = e as SfError;
-      expect(error.message).to.include('native 2GP package version is unretrievable');
-      expect(error.message).to.include('--generate-pkg-zip');
-      expect(error.message).to.include('Then retry retrieving your package metadata');
-      expect(error.message).to.not.include('converted');
+      expect(error.name).to.equal('DownloadDeveloperPackageZipHasNoDataError');
+      expect(error.message).to.equal(
+        "Can't retrieve package metadata. Package metadata is only generated for converted 2GP package versions and versions created with the --generate-pkg-zip flag. To resolve, create a new package version and retry. For native 2GP packages, include the --generate-pkg-zip flag when creating the version. For 1GP packages, first convert them to 2GP."
+      );
     }
   });
 
-  it('should throw the converted-2GP "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is set', async () => {
+  it('should throw the unified "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is set', async () => {
     $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
     queryPackage2VersionStub
       .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
@@ -351,10 +351,10 @@ describe('Package Version Retrieve', () => {
       assert.fail('Expected test execution to raise an error');
     } catch (e) {
       const error = e as SfError;
-      expect(error.message).to.include('converted 2GP package version is unretrievable');
-      expect(error.message).to.include('retry conversion to produce a new converted package version');
-      expect(error.message).to.not.include('--generate-pkg-zip');
-      expect(error.message).to.not.include('native');
+      expect(error.name).to.equal('DownloadDeveloperPackageZipHasNoDataError');
+      expect(error.message).to.equal(
+        "Can't retrieve package metadata. Package metadata is only generated for converted 2GP package versions and versions created with the --generate-pkg-zip flag. To resolve, create a new package version and retry. For native 2GP packages, include the --generate-pkg-zip flag when creating the version. For 1GP packages, first convert them to 2GP."
+      );
     }
   });
 


### PR DESCRIPTION
## Summary
- Auto-generated by claude-unleashed packaging-implementer for W-22570931
- Consolidates two error messages into a unified `DownloadDeveloperPackageZipHasNoDataError`

## Test plan
- [ ] Reviewer agent will run gates and codenod loop
- [ ] Human review of diff before merge

## Override
This PR is part of the 2GP packaging CLI auto-implementer pilot. Treat as a draft until reviewed by a human.