### PR TITLE
@W-21771476: feat: add HasVpi to package version list and report queries [DO NOT MERGE until 6/4 262.8 deploy]

### DIFF
--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -147,6 +147,7 @@ export type PackageVersionListResult = {
   BuildDurationInSeconds?: number;
   HasMetadataRemoved?: boolean;
   Language?: string;
+  HasVpi?: boolean;
 };
 
 export type PackagePushRequestListQueryOptions = {

--- a/src/interfaces/packagingSObjects.ts
+++ b/src/interfaces/packagingSObjects.ts
@@ -75,6 +75,7 @@ export namespace PackagingSObjects {
     TotalNumberOfMetadataFiles: number;
     TotalSizeOfMetadataFiles: number;
     DeveloperUsePkgZip?: string;
+    HasVpi?: boolean;
   };
 
   export enum Package2VersionStatus {

--- a/src/package/packageVersion.ts
+++ b/src/package/packageVersion.ts
@@ -82,6 +82,7 @@ export const Package2VersionFields: Array<keyof Package2Version> = [
   'HasMetadataRemoved',
   'EndToEndBuildDurationInSeconds', // v61.0+
   'DeveloperUsePkgZip', // v64.0+
+  'HasVpi', // v67.0+
 ];
 
 export type Package2VersionFieldTypes = Array<(typeof Package2VersionFields)[number]>;
@@ -425,6 +426,10 @@ export class PackageVersion {
 
     // remove fields that are not available in the connection api version
     const fieldsToExclude: string[] = [];
+
+    if (apiVersion < 67) {
+      fieldsToExclude.push('HasVpi');
+    }
 
     if (apiVersion < 64) {
       fieldsToExclude.push('DeveloperUsePkgZip');

--- a/src/package/packageVersionList.ts
+++ b/src/package/packageVersionList.ts
@@ -55,6 +55,8 @@ const verboseFields = ['CodeCoverage', 'HasPassedCodeCoverageCheck'];
 
 const verbose57Fields = ['Language'];
 
+const verbose67Fields = ['HasVpi'];
+
 // Ensure we only include the async validation property for api version of v60.0 or higher.
 const default61Fields = ['ValidatedAsync'];
 
@@ -91,6 +93,9 @@ export function constructQuery(connectionVersion: number, options?: PackageVersi
     queryFields = [...queryFields, ...verboseFields];
     if (connectionVersion >= 57) {
       queryFields = [...queryFields, ...verbose57Fields];
+    }
+    if (connectionVersion >= 67) {
+      queryFields = [...queryFields, ...verbose67Fields];
     }
   }
   const query = `SELECT ${queryFields.toString()} FROM Package2Version`;

--- a/src/package/packageVersionReport.ts
+++ b/src/package/packageVersionReport.ts
@@ -70,17 +70,18 @@ const getLogger = (): Logger => {
 };
 
 function constructQuery(connectionVersion: number, verbose: boolean): string {
-  // Ensure we only include the async validation property for api version of v60.0 or higher.
-  // TotalNumberOfMetadataFiles is included as query field for api version of v64.0 or higher.
+  // ValidatedAsync is included for api version v61.0 or higher.
+  // TotalNumberOfMetadataFiles, TotalSizeOfMetadataFiles are included for api version v64.0 or higher.
+  // HasVpi is included for api version v67.0 or higher.
   let queryFields =
-    connectionVersion > 66
+    connectionVersion >= 67
       ? [...defaultFields, ...default61Fields, ...default64Fields, ...default67Fields]
-      : connectionVersion > 63
+      : connectionVersion >= 64
       ? [...defaultFields, ...default61Fields, ...default64Fields]
-      : connectionVersion > 60
+      : connectionVersion >= 61
       ? [...defaultFields, ...default61Fields]
       : defaultFields;
-  verboseFields = connectionVersion > 60 ? [...verboseFields, ...verbose61Fields] : verboseFields;
+  verboseFields = connectionVersion >= 61 ? [...verboseFields, ...verbose61Fields] : verboseFields;
   if (verbose) {
     queryFields = [...queryFields, ...verboseFields];
   }

--- a/src/package/packageVersionReport.ts
+++ b/src/package/packageVersionReport.ts
@@ -55,6 +55,8 @@ const default61Fields = ['ValidatedAsync'];
 // Add fields here that are available only api version of v64.0 or higher.
 const default64Fields = ['TotalNumberOfMetadataFiles', 'TotalSizeOfMetadataFiles'];
 
+const default67Fields = ['HasVpi'];
+
 const verbose61Fields = ['EndToEndBuildDurationInSeconds'];
 
 const DEFAULT_ORDER_BY_FIELDS = 'Package2Id, Branch, MajorVersion, MinorVersion, PatchVersion, BuildNumber';
@@ -71,7 +73,9 @@ function constructQuery(connectionVersion: number, verbose: boolean): string {
   // Ensure we only include the async validation property for api version of v60.0 or higher.
   // TotalNumberOfMetadataFiles is included as query field for api version of v64.0 or higher.
   let queryFields =
-    connectionVersion > 63
+    connectionVersion > 66
+      ? [...defaultFields, ...default61Fields, ...default64Fields, ...default67Fields]
+      : connectionVersion > 63
       ? [...defaultFields, ...default61Fields, ...default64Fields]
       : connectionVersion > 60
       ? [...defaultFields, ...default61Fields]

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -215,6 +215,22 @@ describe('Integration tests for @salesforce/packaging library', () => {
         expect(p2v).to.include('DeveloperUsePkgZip');
       });
 
+      it('should not contain HasVpi field with api version 66', async () => {
+        const connection = devHubOrg.getConnection();
+        connection.setApiVersion('66.0');
+        // @ts-expect-error using a private method for testing
+        const p2v = PackageVersion.getPackage2VersionFields(connection);
+        expect(p2v).to.not.include('HasVpi');
+      });
+
+      it('should contain HasVpi field with api version 67', async () => {
+        const connection = devHubOrg.getConnection();
+        connection.setApiVersion('67.0');
+        // @ts-expect-error using a private method for testing
+        const p2v = PackageVersion.getPackage2VersionFields(connection);
+        expect(p2v).to.include('HasVpi');
+      });
+
       it('should return expected results when querying Package2Version, with fields', async () => {
         const connection = devHubOrg.getConnection();
         const fields = ['Id', 'Name'] satisfies Package2VersionFieldTypes;

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -406,6 +406,9 @@ describe('Integration tests for @salesforce/packaging library', () => {
 
       expect(result.IsReleased, 'Expected IsReleased to be false').to.be.false;
       expect(result.ValidatedAsync, 'Expected ValidatedAsync to be false').to.be.false;
+      if (Number(devHubOrg.getConnection().version) >= 67) {
+        expect(result.HasVpi, 'Expected HasVpi to be false').to.be.false;
+      }
       expect(Object.values(projectFile.packageAliases ?? []).some((id) => id === subscriberPkgVersionId)).to.be.true;
     });
 

--- a/test/package/packageTest.nut.ts
+++ b/test/package/packageTest.nut.ts
@@ -217,18 +217,22 @@ describe('Integration tests for @salesforce/packaging library', () => {
 
       it('should not contain HasVpi field with api version 66', async () => {
         const connection = devHubOrg.getConnection();
+        const originalVersion = connection.getApiVersion();
         connection.setApiVersion('66.0');
         // @ts-expect-error using a private method for testing
         const p2v = PackageVersion.getPackage2VersionFields(connection);
         expect(p2v).to.not.include('HasVpi');
+        connection.setApiVersion(originalVersion);
       });
 
       it('should contain HasVpi field with api version 67', async () => {
         const connection = devHubOrg.getConnection();
+        const originalVersion = connection.getApiVersion();
         connection.setApiVersion('67.0');
         // @ts-expect-error using a private method for testing
         const p2v = PackageVersion.getPackage2VersionFields(connection);
         expect(p2v).to.include('HasVpi');
+        connection.setApiVersion(originalVersion);
       });
 
       it('should return expected results when querying Package2Version, with fields', async () => {

--- a/test/package/packageVersionList.test.ts
+++ b/test/package/packageVersionList.test.ts
@@ -141,10 +141,11 @@ describe('package version list', () => {
         modifiedLastDays: 2,
         isReleased: true,
       };
-      const constQuery = constructQuery(59, options);
+      const constQuery = constructQuery(67, options);
       expect(constQuery).to.not.include('CodeCoverage');
       expect(constQuery).to.not.include('HasPassedCodeCoverageCheck');
       expect(constQuery).to.not.include('Language');
+      expect(constQuery).to.not.include('HasVpi');
     });
 
     it('should include validatedAsync field', async () => {
@@ -167,6 +168,30 @@ describe('package version list', () => {
       };
       const constQuery = constructQuery(59, options);
       expect(constQuery).to.not.include('ValidatedAsync');
+    });
+
+    it('should include HasVpi in verbose at api version 67', async () => {
+      const options = {
+        packages: ['0Ho3h000000xxxxCAG'],
+        createdLastDays: 1,
+        modifiedLastDays: 2,
+        isReleased: true,
+        verbose: true,
+      };
+      const constQuery = constructQuery(67, options);
+      expect(constQuery).to.include('HasVpi');
+    });
+
+    it('should not include HasVpi in verbose at api version 66', async () => {
+      const options = {
+        packages: ['0Ho3h000000xxxxCAG'],
+        createdLastDays: 1,
+        modifiedLastDays: 2,
+        isReleased: true,
+        verbose: true,
+      };
+      const constQuery = constructQuery(66, options);
+      expect(constQuery).to.not.include('HasVpi');
     });
   });
 


### PR DESCRIPTION
@W-21771476@

## Summary
- Add `HasVpi` boolean field to package version list and report queries
- Version-gated at API v67+ (app version 262)
- Field added to `Package2VersionFields`, `verboseFields` (list), and `default67Fields` (report)
- Unit tests + NUT tests for version gate behavior

## Dependencies
- Requires W-21771475 (262.8 patch) to be fully deployed (scheduled 6/4)
- Plugin-packaging PR depends on this merging first

## Test plan
- [x] Unit tests: `constructQuery(67, verbose)` includes HasVpi, `constructQuery(66, verbose)` excludes it
- [x] NUT tests: `getPackage2VersionFields` at v66 excludes, v67 includes
- [x] Manual testing on 262 devhub (hub0318) and 260 devhub (hub1215)

🤖 Generated with [Claude Code](https://claude.com/claude-code)