### PR TITLE
feat: @w-22893150 - add support for FragmentBundle metadata

### DIFF
--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -1008,13 +1008,7 @@ export class MetadataResolver {
         throw messages.createError('packagePathCannotBeUndefined');
       }
       copyDir(convertResult.packagePath, outputDirectory);
-      try {
-        fs.rmSync(convertResult.packagePath, { recursive: true });
-      } catch (e) {
-        // rmdirSync is being deprecated and emits a warning
-        // but rmSync is introduced in node 14 so fall back to rmdirSync
-        fs.rmdirSync(convertResult.packagePath, { recursive: true });
-      }
+      fs.rmSync(convertResult.packagePath, { recursive: true });
 
       convertResult.packagePath = outputDirectory;
     }


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation error: replace deprecated `fs.rmdirSync` with `fs.rmSync` in packageVersionCreate.ts

## Test plan
- [x] `yarn build` succeeds
- [x] Plugin builds and links correctly with sf CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)