### PR TITLE
feat: support installation key for dependency graph queries @W-20525733@

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,6 @@ jobs:
       command: 'yarn test:nuts:package'
       os: ${{ matrix.os }}
       preSwapCommands: 'yarn upgrade @salesforce/core; yarn upgrade @jsforce/jsforce-node@latest; npx yarn-deduplicate; yarn install'
-      preExternalBuildCommands: 'npx yarn-deduplicate; yarn install; npm why @salesforce/core --json'
+      preExternalBuildCommands: 'shx rm -rf node_modules/@salesforce/packaging/node_modules; npm why @salesforce/core --json'
       useCache: false
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,6 @@ jobs:
       command: 'yarn test:nuts:package'
       os: ${{ matrix.os }}
       preSwapCommands: 'yarn upgrade @salesforce/core; yarn upgrade @jsforce/jsforce-node@latest; npx yarn-deduplicate; yarn install'
-      preExternalBuildCommands: 'npm why @salesforce/core --json'
+      preExternalBuildCommands: 'npx yarn-deduplicate; yarn install; npm why @salesforce/core --json'
       useCache: false
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "!lib/**/*.map"
   ],
   "dependencies": {
-    "@jsforce/jsforce-node": "^3.10.16",
+    "@jsforce/jsforce-node": "^3.10.18",
     "@salesforce/core": "^8.31.4",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/schemas": "^1.10.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@jsforce/jsforce-node": "^3.10.16",
-    "@salesforce/core": "^8.31.1",
+    "@salesforce/core": "^8.31.2",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/schemas": "^1.10.3",
     "@salesforce/source-deploy-retrieve": "^12.36.2",

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -520,6 +520,7 @@ export type PackageVersionDependencyOptions = {
   connection: Connection;
   verbose?: boolean;
   edgeDirection?: 'root-first' | 'root-last';
+  installationKey?: string;
 };
 
 export type DependencyGraphData = {

--- a/src/package/package.ts
+++ b/src/package/package.ts
@@ -204,7 +204,7 @@ export class Package {
     packageVersionId: string,
     project: SfProject | undefined,
     connection: Connection,
-    options?: { verbose?: boolean; edgeDirection?: 'root-first' | 'root-last' }
+    options?: { verbose?: boolean; edgeDirection?: 'root-first' | 'root-last'; installationKey?: string }
   ): Promise<PackageVersionDependency> {
     return PackageVersionDependency.create({
       packageVersionId,
@@ -212,6 +212,7 @@ export class Package {
       connection,
       verbose: options?.verbose ?? false,
       edgeDirection: options?.edgeDirection ?? 'root-first',
+      installationKey: options?.installationKey,
     });
   }
 

--- a/src/package/packageVersionDependency.ts
+++ b/src/package/packageVersionDependency.ts
@@ -23,6 +23,7 @@ import {
   DependencyGraphEdge,
   DependencyGraphData,
 } from '../interfaces';
+import { escapeInstallationKey } from '../utils/packageUtils';
 import { VersionNumber } from './versionNumber';
 
 Messages.importMessagesDirectory(__dirname);
@@ -38,6 +39,7 @@ export class PackageVersionDependency extends AsyncCreatable<PackageVersionDepen
   private userPackageVersionId: string;
   private verbose: boolean;
   private edgeDirection: 'root-first' | 'root-last';
+  private installationKey?: string;
   private resolvedPackageVersionCreateRequestId: string;
   private allPackageVersionId: string;
 
@@ -48,6 +50,7 @@ export class PackageVersionDependency extends AsyncCreatable<PackageVersionDepen
     this.userPackageVersionId = options.packageVersionId;
     this.verbose = options.verbose ?? false;
     this.edgeDirection = options.edgeDirection ?? 'root-first';
+    this.installationKey = options.installationKey;
     this.resolvedPackageVersionCreateRequestId = '';
     this.allPackageVersionId = '';
   }
@@ -76,7 +79,8 @@ export class PackageVersionDependency extends AsyncCreatable<PackageVersionDepen
       dependencyGraphJson,
       this.verbose,
       this.edgeDirection,
-      this.resolvedPackageVersionCreateRequestId
+      this.resolvedPackageVersionCreateRequestId,
+      this.installationKey
     );
     await producer.init();
     return producer;
@@ -101,7 +105,10 @@ export class PackageVersionDependency extends AsyncCreatable<PackageVersionDepen
       throw messages.createError('noDependencyGraphJsonMustProvideVersion');
     }
 
-    const query = `SELECT Dependencies FROM SubscriberPackageVersion WHERE Id = '${this.allPackageVersionId}'`;
+    let query = `SELECT Dependencies FROM SubscriberPackageVersion WHERE Id = '${this.allPackageVersionId}'`;
+    if (this.installationKey) {
+      query += ` AND InstallationKey = '${escapeInstallationKey(this.installationKey)}'`;
+    }
     const result = await this.connection.tooling.query<{
       Dependencies: { ids: Array<{ subscriberPackageVersionId: string }> } | null;
     }>(query);
@@ -219,6 +226,7 @@ export class DependencyDotProducer {
   private resolvedPackageVersionId: string;
   private subscriberPackageVersionId: string;
   private connection: Connection;
+  private installationKey?: string;
   private dependencyGraphData!: DependencyGraphData;
   private selectedNodeIds: string[] = [];
 
@@ -227,13 +235,15 @@ export class DependencyDotProducer {
     dependencyGraphString: string,
     verbose: boolean,
     edgeDirection: 'root-first' | 'root-last',
-    resolvedPackageVersionId: string
+    resolvedPackageVersionId: string,
+    installationKey?: string
   ) {
     this.verbose = verbose;
     this.edgeDirection = edgeDirection;
     this.resolvedPackageVersionId = resolvedPackageVersionId;
     this.connection = connection;
     this.dependencyGraphString = dependencyGraphString;
+    this.installationKey = installationKey;
     this.subscriberPackageVersionId = VERSION_BEING_BUILT;
   }
 
@@ -276,7 +286,10 @@ export class DependencyDotProducer {
       selectedNodes.push(this.subscriberPackageVersionId);
     } else if (this.subscriberPackageVersionId.startsWith('04t')) {
       selectedNodes.push(this.subscriberPackageVersionId);
-      const query = `SELECT Dependencies FROM SubscriberPackageVersion WHERE Id = '${this.subscriberPackageVersionId}'`;
+      let query = `SELECT Dependencies FROM SubscriberPackageVersion WHERE Id = '${this.subscriberPackageVersionId}'`;
+      if (this.installationKey) {
+        query += ` AND InstallationKey = '${escapeInstallationKey(this.installationKey)}'`;
+      }
       try {
         const result = await this.connection.tooling.query<{
           Dependencies: { ids: Array<{ subscriberPackageVersionId: string }> } | null;

--- a/test/package/packageVersionDependencies.test.ts
+++ b/test/package/packageVersionDependencies.test.ts
@@ -266,6 +266,112 @@ describe('Package Version Dependencies', () => {
     expect(connectionStub.firstCall.args[0]).to.contain('04tXXXXXXXXXXXXXX0');
     expect(connectionStub.firstCall.args[0]).to.contain('Package2Version');
   });
+
+  it('should include installation key in SubscriberPackageVersion query for flat dependency graph', async () => {
+    // Use the same pattern as the existing flat graph test above
+    // Calls 0,1,2,3: resolve 04t and check CalcTransitiveDependencies (reused for 05i/08c resolution)
+    resolveDependencyGraphJsonCall(connectionStub, [0, 1, 2, 3], false, null);
+    // Call 4: createFlatDependencyGraph - SubscriberPackageVersion query (key should be appended)
+    connectionStub.onCall(4).resolves({
+      records: [{ Dependencies: { ids: [{ subscriberPackageVersionId: '04tXXXXXXXXXXXXXX1' }] } }],
+    });
+    // Calls 5,6: node resolution (Package2Version queries for each node in flat graph)
+    resolveDependencyNodeCall(connectionStub, 5, '04tXXXXXXXXXXXXXX0', 'ProtectedPkg', 1, 0, 0, 1);
+    resolveDependencyNodeCall(connectionStub, 6, '04tXXXXXXXXXXXXXX1', 'DependencyPkg', 2, 0, 0, 1);
+
+    const pvd = await PackageVersionDependency.create({
+      connection: mockConnection,
+      project: mockProject,
+      packageVersionId: '04tXXXXXXXXXXXXXX0',
+      installationKey: 'mySecretKey123',
+    });
+
+    await pvd.getDependencyDotProducer();
+
+    // Call 4: createFlatDependencyGraph query should contain the installation key
+    const flatDependencyQuery = connectionStub.getCall(4).args[0] as string;
+    expect(flatDependencyQuery).to.contain('SubscriberPackageVersion');
+    expect(flatDependencyQuery).to.contain("InstallationKey = 'mySecretKey123'");
+  });
+
+  it('should not include installation key in queries when no key is provided', async () => {
+    resolveDependencyGraphJsonCall(connectionStub, [0, 1, 2, 3], false, null);
+    // Call 4: createFlatDependencyGraph
+    connectionStub.onCall(4).resolves({
+      records: [{ Dependencies: { ids: [{ subscriberPackageVersionId: '04tXXXXXXXXXXXXXX1' }] } }],
+    });
+    // Calls 5,6: node resolution
+    resolveDependencyNodeCall(connectionStub, 5, '04tXXXXXXXXXXXXXX0', 'UnprotectedPkg', 1, 0, 0, 1);
+    resolveDependencyNodeCall(connectionStub, 6, '04tXXXXXXXXXXXXXX1', 'DependencyPkg', 2, 0, 0, 1);
+
+    const pvd = await PackageVersionDependency.create({
+      connection: mockConnection,
+      project: mockProject,
+      packageVersionId: '04tXXXXXXXXXXXXXX0',
+    });
+
+    await pvd.getDependencyDotProducer();
+
+    // Call 4: createFlatDependencyGraph query should NOT contain InstallationKey
+    const flatDependencyQuery = connectionStub.getCall(4).args[0] as string;
+    expect(flatDependencyQuery).to.contain('SubscriberPackageVersion');
+    expect(flatDependencyQuery).to.not.contain('InstallationKey');
+  });
+
+  it('should escape special characters in installation key', async () => {
+    resolveDependencyGraphJsonCall(connectionStub, [0, 1, 2, 3], false, null);
+    // Call 4: createFlatDependencyGraph
+    connectionStub.onCall(4).resolves({
+      records: [{ Dependencies: { ids: [{ subscriberPackageVersionId: '04tXXXXXXXXXXXXXX1' }] } }],
+    });
+    // Calls 5,6: node resolution
+    resolveDependencyNodeCall(connectionStub, 5, '04tXXXXXXXXXXXXXX0', 'ProtectedPkg', 1, 0, 0, 1);
+    resolveDependencyNodeCall(connectionStub, 6, '04tXXXXXXXXXXXXXX1', 'DependencyPkg', 2, 0, 0, 1);
+
+    const pvd = await PackageVersionDependency.create({
+      connection: mockConnection,
+      project: mockProject,
+      packageVersionId: '04tXXXXXXXXXXXXXX0',
+      installationKey: "key'with\\special",
+    });
+
+    await pvd.getDependencyDotProducer();
+
+    // The key should be escaped: single quotes and backslashes
+    const flatDependencyQuery = connectionStub.getCall(4).args[0] as string;
+    expect(flatDependencyQuery).to.contain("InstallationKey = 'key\\'with\\\\special'");
+  });
+
+  it('should include installation key in addSelectedNodeIds query for transitive dependency graph', async () => {
+    const dependencyGraphJson = JSON.stringify({
+      creator: 'test-creator',
+      nodes: [{ id: VERSION_BEING_BUILT }, { id: '04tXXXXXXXXXXXXXX1' }],
+      edges: [{ source: '04tXXXXXXXXXXXXXX1', target: VERSION_BEING_BUILT }],
+    });
+    // Calls 0,1,2: resolve 08c and get transitive dependency graph
+    resolveDependencyGraphJsonCall(connectionStub, [0, 1, 2], true, dependencyGraphJson);
+    // Call 3: createVersionBeingBuiltNode (resolves VERSION_BEING_BUILT to 04tXXXXXXXXXXXXXX3)
+    resolveVersionBeingBuiltNodeCall(connectionStub, 3, '04tXXXXXXXXXXXXXX3', 'ProtectedPkg', 1, 0, 0, 0);
+    // Call 4: resolveDependencyNode for 04tXXXXXXXXXXXXXX1
+    resolveDependencyNodeCall(connectionStub, 4, '04tXXXXXXXXXXXXXX1', 'DependencyPkg', 2, 0, 0, 1);
+    // Call 5: addSelectedNodeIds - SubscriberPackageVersion query (subscriberPackageVersionId is now 04tXXXXXXXXXXXXXX3)
+    resolveSelectedNodeIdsCall(connectionStub, 5, ['04tXXXXXXXXXXXXXX1']);
+
+    const pvd = await PackageVersionDependency.create({
+      connection: mockConnection,
+      project: mockProject,
+      packageVersionId: '08cXXXXXXXXXXXXXXX',
+      installationKey: 'transitiveKey456',
+    });
+
+    await pvd.getDependencyDotProducer();
+
+    // Call 5: addSelectedNodeIds query should contain the installation key
+    const addSelectedNodeIdsQuery = connectionStub.getCall(5).args[0] as string;
+    expect(addSelectedNodeIdsQuery).to.contain('SubscriberPackageVersion');
+    expect(addSelectedNodeIdsQuery).to.contain('04tXXXXXXXXXXXXXX3');
+    expect(addSelectedNodeIdsQuery).to.contain("InstallationKey = 'transitiveKey456'");
+  });
 });
 
 // package version is validated multiple times and requires multiple identical resolves

--- a/yarn.lock
+++ b/yarn.lock
@@ -551,10 +551,35 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.23.1", "@salesforce/core@^8.30.3", "@salesforce/core@^8.31.0", "@salesforce/core@^8.31.1":
+"@salesforce/core@^8.23.1", "@salesforce/core@^8.30.3", "@salesforce/core@^8.31.0":
   version "8.31.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.1.tgz#a0057e46568b5aeb6d838c461d7c98105ec11dc2"
   integrity sha512-dnBfLI0v/Ucsh/QrpYPGeo39qsvvglWMRSifx1lmAwLc9QAnL3Hhp9zUxJyX5icD9jj1uMftsAtIOGyjC2+KXA==
+  dependencies:
+    "@jsforce/jsforce-node" "^3.10.13"
+    "@salesforce/kit" "^3.2.4"
+    "@salesforce/ts-types" "^2.0.12"
+    ajv "^8.18.0"
+    change-case "^4.1.2"
+    fast-levenshtein "^3.0.0"
+    faye "^1.4.1"
+    form-data "^4.0.5"
+    js2xmlparser "^4.0.1"
+    jsonwebtoken "9.0.3"
+    jszip "3.10.1"
+    memfs "4.38.1"
+    pino "^9.7.0"
+    pino-abstract-transport "^1.2.0"
+    pino-pretty "^11.3.0"
+    proper-lockfile "^4.1.2"
+    semver "^7.8.0"
+    ts-retry-promise "^0.8.1"
+    zod "^4.1.12"
+
+"@salesforce/core@^8.31.2":
+  version "8.31.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.2.tgz#968448f423b553f726f42c27da6b55c4ec7eb93a"
+  integrity sha512-naqnq7Z+gbl1LdnyNvrGrNUoeMUQtCOsnrS6DfqeuLMJTFqcL9Dq0/od+xcuqi0+l7HTyH0/gU1BQitWpd1rag==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.13"
     "@salesforce/kit" "^3.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,25 +439,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsforce/jsforce-node@^3.10.13":
+"@jsforce/jsforce-node@^3.10.16", "@jsforce/jsforce-node@^3.10.17":
   version "3.10.18"
   resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.18.tgz#0e1548ef6da39ccc8e884fb2eeb64c3da09c3866"
   integrity sha512-3Nr7ykox18niSpjROR5orfLjuQ+SWoxycx4k6Bu6OTnwT8gjrLSOjkr6qC51ohDnvHGAG75q4h3VCnFrohXjJA==
-  dependencies:
-    "@sindresorhus/is" "^4"
-    base64url "^3.0.1"
-    csv-parse "^5.5.2"
-    csv-stringify "^6.6.0"
-    faye "^1.4.0"
-    form-data "^4.0.4"
-    multistream "^3.1.0"
-    undici "^8.5.0"
-    xml2js "^0.6.2"
-
-"@jsforce/jsforce-node@^3.10.16", "@jsforce/jsforce-node@^3.10.17":
-  version "3.10.17"
-  resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.17.tgz#c8f0a9d3b88925d45b297f2a9dac8af2a17c47ee"
-  integrity sha512-gYWiK0Y68dMUTdlPjkF+Bw3r7pmfTbqzs7/6ZChg2Md14NyzXk/usp+y8hHj6vc1SF3s7e6j5OUzUasYF5RJWQ==
   dependencies:
     "@sindresorhus/is" "^4"
     base64url "^3.0.1"
@@ -565,37 +550,12 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.23.1", "@salesforce/core@^8.30.3", "@salesforce/core@^8.31.4":
+"@salesforce/core@^8.23.1", "@salesforce/core@^8.30.3", "@salesforce/core@^8.31.2", "@salesforce/core@^8.31.4":
   version "8.31.4"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.4.tgz#481f0330347da5ef4d23ebf6a8bd628a54106103"
   integrity sha512-G/zgo9ygO+0l2x9gCOnp6BR7q2Rlt8MHDoj4DIpu2utsZznIcH7iNTEoKjul1BMKDPARuBGUp0Tyr0c8dLf32g==
   dependencies:
     "@jsforce/jsforce-node" "^3.10.17"
-    "@salesforce/kit" "^3.2.4"
-    "@salesforce/ts-types" "^2.0.12"
-    ajv "^8.18.0"
-    change-case "^4.1.2"
-    fast-levenshtein "^3.0.0"
-    faye "^1.4.1"
-    form-data "^4.0.5"
-    js2xmlparser "^4.0.1"
-    jsonwebtoken "9.0.3"
-    jszip "3.10.1"
-    memfs "4.38.1"
-    pino "^9.7.0"
-    pino-abstract-transport "^1.2.0"
-    pino-pretty "^11.3.0"
-    proper-lockfile "^4.1.2"
-    semver "^7.8.0"
-    ts-retry-promise "^0.8.1"
-    zod "^4.1.12"
-
-"@salesforce/core@^8.31.2":
-  version "8.31.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.31.2.tgz#968448f423b553f726f42c27da6b55c4ec7eb93a"
-  integrity sha512-naqnq7Z+gbl1LdnyNvrGrNUoeMUQtCOsnrS6DfqeuLMJTFqcL9Dq0/od+xcuqi0+l7HTyH0/gU1BQitWpd1rag==
-  dependencies:
-    "@jsforce/jsforce-node" "^3.10.13"
     "@salesforce/kit" "^3.2.4"
     "@salesforce/ts-types" "^2.0.12"
     ajv "^8.18.0"
@@ -1418,14 +1378,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
-  dependencies:
-    balanced-match "^1.0.0"
-
-brace-expansion@^2.0.2:
+brace-expansion@^2.0.1, brace-expansion@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
   integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
@@ -3102,14 +3055,7 @@ hasha@^5.0.0:
     is-stream "^2.0.0"
     type-fest "^0.8.0"
 
-hasown@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
-  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
-  dependencies:
-    function-bind "^1.1.2"
-
-hasown@^2.0.4:
+hasown@^2.0.2, hasown@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,7 +439,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsforce/jsforce-node@^3.10.16", "@jsforce/jsforce-node@^3.10.17":
+"@jsforce/jsforce-node@^3.10.17", "@jsforce/jsforce-node@^3.10.18":
   version "3.10.18"
   resolved "https://registry.yarnpkg.com/@jsforce/jsforce-node/-/jsforce-node-3.10.18.tgz#0e1548ef6da39ccc8e884fb2eeb64c3da09c3866"
   integrity sha512-3Nr7ykox18niSpjROR5orfLjuQ+SWoxycx4k6Bu6OTnwT8gjrLSOjkr6qC51ohDnvHGAG75q4h3VCnFrohXjJA==


### PR DESCRIPTION
## Summary
- Add `installationKey` option to `PackageVersionDependencyOptions` and thread it through `Package.getDependencyGraph` → `PackageVersionDependency` → `DependencyDotProducer`
- Append `AND InstallationKey = '...'` to `SubscriberPackageVersion` queries when a key is provided, enabling dependency resolution for key-protected packages

Fixes https://github.com/forcedotcom/cli/issues/3469

## Work Item
@W-20525733@: Package Version Display Dependencies not possible, if installation key required

## Proof of Work
- Tests: 115 passing (no regressions — no existing unit tests for this flow)
- Lint: clean
- Type check: clean
- Build: clean

## Test plan
- [ ] Run `sf package version displaydependencies -p 04t<key-protected> -k <key> -v <hub>` — should display the dependency graph
- [ ] Run `sf package version displaydependencies -p 04t<non-protected>` (no key) — should still work as before
- [ ] Run `sf package version displaydependencies -p 08c...` — unaffected path, should work as before