### PR TITLE
fix: disambiguate package version retrieve errors (@W-23089623@)

### DIFF
--- a/messages/package.md
+++ b/messages/package.md
@@ -38,6 +38,14 @@ Can't retrieve package version metadata. The specified directory must be relativ
 
 Can't retrieve package metadata. To use this feature, you must first assign yourself the DownloadPackageVersionZips user permission. Then retry retrieving your package metadata.
 
+# packageVersionNotFound
+
+Can't retrieve package metadata. We can't find the package version %s. Verify that the 04t ID is correct and that the package version exists.
+
+# packageVersionNotInDevHub
+
+Can't retrieve package metadata. Package version %s isn't accessible from this Dev Hub org. You can only retrieve package metadata from the Dev Hub that created the package version. Verify that you specified the correct target Dev Hub.
+
 # downloadDeveloperPackageZipHasNoDataNative2GP
 
 Can't retrieve package metadata. The developer package zip for this native 2GP package version is unretrievable. To resolve, create a new package version with the --generate-pkg-zip flag. Then retry retrieving your package metadata.

--- a/src/package/packageVersionRetrieve.ts
+++ b/src/package/packageVersionRetrieve.ts
@@ -24,7 +24,12 @@ import {
   PackageVersionMetadataDownloadResult,
   PackagingSObjects,
 } from '../interfaces';
-import { generatePackageAliasEntry, isPackageDirectoryEffectivelyEmpty } from '../utils/packageUtils';
+import {
+  BY_LABEL,
+  generatePackageAliasEntry,
+  isPackageDirectoryEffectivelyEmpty,
+  validateIdNoThrow,
+} from '../utils/packageUtils';
 import { createPackageDirEntry } from './packageCreate';
 import { Package } from './package';
 import { PackageVersion, Package2VersionFieldTypes } from './packageVersion';
@@ -226,11 +231,18 @@ async function attemptToUpdateProjectJson(
  * columns any authenticated user can read, so the query always succeeds; selecting DeveloperUsePkgZip
  * here (which requires the DownloadPackageVersionZips permission) would throw "No such column" for a
  * user without that permission and mask those cases as a permission problem.
+ *
+ * Rejects a syntactically invalid 04t up front so it maps to packageVersionNotFound rather than
+ * leaking a raw "invalid ID field" SOQL error from the interpolated where clause.
  */
 async function resolvePackage2Version(
   connection: Connection,
   subscriberPackageVersionId: string
 ): Promise<PackagingSObjects.Package2Version> {
+  if (!validateIdNoThrow(BY_LABEL.SUBSCRIBER_PACKAGE_VERSION_ID, subscriberPackageVersionId)) {
+    throw messages.createError('packageVersionNotFound', [subscriberPackageVersionId]);
+  }
+
   const queryOptions = {
     whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
     fields: ['Package2Id', 'ConvertedFromVersionId'] as Package2VersionFieldTypes,

--- a/src/package/packageVersionRetrieve.ts
+++ b/src/package/packageVersionRetrieve.ts
@@ -23,7 +23,7 @@ import { PackageVersionMetadataDownloadOptions, PackageVersionMetadataDownloadRe
 import { generatePackageAliasEntry, isPackageDirectoryEffectivelyEmpty } from '../utils/packageUtils';
 import { createPackageDirEntry } from './packageCreate';
 import { Package } from './package';
-import { PackageVersion } from './packageVersion';
+import { PackageVersion, Package2VersionFieldTypes } from './packageVersion';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/packaging', 'package');
@@ -56,35 +56,46 @@ export async function retrievePackageVersionMetadata(
     throw messages.createError('sourcesDownloadDirectoryNotEmpty');
   }
 
-  // Get the DeveloperUsePkgZip URL from the Package2Version record
+  // Resolve an alias to the underlying 04t if one was passed.
   const subscriberPackageVersionId =
     project.getPackageIdFromAlias(options.subscriberPackageVersionId) ?? options.subscriberPackageVersionId;
 
-  // Query Package2Version to get the record by SubscriberPackageVersionId
+  // Select only the columns this flow reads. Omitting the permission-gated DeveloperUsePkgZip
+  // keeps this query from throwing "No such column" before we can disambiguate the failure.
   const queryOptions = {
     whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
+    fields: ['Package2Id', 'ConvertedFromVersionId'] as Package2VersionFieldTypes,
   };
   let versionInfo;
   try {
     [versionInfo] = await PackageVersion.queryPackage2Version(connection, queryOptions);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    if (msg.includes("No such column 'DeveloperUsePkgZip' on entity 'Package2Version'")) {
-      throw messages.createError('developerUsePkgZipFieldUnavailable');
-    }
     if (msg.includes("sObject type 'Package2Version' is not supported.")) {
       throw messages.createError('packagingNotEnabledOnOrg');
     }
     throw e;
   }
 
-  if (!versionInfo?.DeveloperUsePkgZip) {
+  // Not in this Dev Hub: tell "doesn't exist anywhere" apart from "exists but not here".
+  if (!versionInfo) {
+    const exists = await subscriberPackageVersionExists(connection, subscriberPackageVersionId);
+    throw messages.createError(exists ? 'packageVersionNotInDevHub' : 'packageVersionNotFound', [
+      subscriberPackageVersionId,
+    ]);
+  }
+
+  // Row exists; fetch the download URL separately. No URL means the user lacks the permission.
+  const developerUsePkgZipUrl = await getDeveloperUsePkgZipUrl(connection, subscriberPackageVersionId);
+  if (!developerUsePkgZipUrl) {
     throw messages.createError('developerUsePkgZipFieldUnavailable');
   }
 
-  const responseBase64 = await connection.tooling.request<string>(versionInfo.DeveloperUsePkgZip, {
-    encoding: 'base64',
-  });
+  const responseBase64 = await downloadDeveloperPackageZip(
+    connection,
+    developerUsePkgZipUrl,
+    subscriberPackageVersionId
+  );
   const buffer = Buffer.from(responseBase64, 'base64');
 
   let tree;
@@ -230,5 +241,67 @@ async function attemptToUpdateProjectJson(
     logger.error(
       `Encountered error trying to update sfdx-project.json after retrieving package version metadata: ${msg as string}`
     );
+  }
+}
+
+/** Download the package zip, mapping the servlet's late-stage access failures to actionable errors. */
+async function downloadDeveloperPackageZip(
+  connection: Connection,
+  developerUsePkgZipUrl: string,
+  subscriberPackageVersionId: string
+): Promise<string> {
+  try {
+    return await connection.tooling.request<string>(developerUsePkgZipUrl, { encoding: 'base64' });
+  } catch (e) {
+    const name = e instanceof Error ? e.name : '';
+    if (name === 'NOT_FOUND') {
+      throw messages.createError('packageVersionNotFound', [subscriberPackageVersionId]);
+    }
+    if (name === 'INSUFFICIENT_ACCESS' || name === 'INSUFFICIENT_ACCESS_OR_READONLY') {
+      throw messages.createError('packageVersionNotInDevHub', [subscriberPackageVersionId]);
+    }
+    throw e;
+  }
+}
+
+/**
+ * Fetch the permission-gated DeveloperUsePkgZip download URL on its own. Returns undefined when the
+ * user can't access it, so both an empty value and its "No such column" error read the same.
+ */
+async function getDeveloperUsePkgZipUrl(
+  connection: Connection,
+  subscriberPackageVersionId: string
+): Promise<string | undefined> {
+  try {
+    const [record] = await PackageVersion.queryPackage2Version(connection, {
+      whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
+      fields: ['DeveloperUsePkgZip'] as Package2VersionFieldTypes,
+    });
+    return record?.DeveloperUsePkgZip ?? undefined;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("No such column 'DeveloperUsePkgZip' on entity 'Package2Version'")) {
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+/**
+ * True if a SubscriberPackageVersion with this 04t ID exists anywhere. That global view is
+ * queryable by any authenticated user, so it tells "not found" apart from "not in this Dev Hub".
+ */
+async function subscriberPackageVersionExists(
+  connection: Connection,
+  subscriberPackageVersionId: string
+): Promise<boolean> {
+  try {
+    const result = await connection.tooling.query<{ Id: string }>(
+      `SELECT Id FROM SubscriberPackageVersion WHERE Id = '${subscriberPackageVersionId}' LIMIT 1`
+    );
+    return (result.records?.length ?? 0) > 0;
+  } catch {
+    // If even the existence probe fails (malformed ID, etc.), fall back to "not found".
+    return false;
   }
 }

--- a/src/package/packageVersionRetrieve.ts
+++ b/src/package/packageVersionRetrieve.ts
@@ -19,7 +19,11 @@ import { Connection, Logger, Messages, SfProject } from '@salesforce/core';
 import { ComponentSet, MetadataConverter, ZipTreeContainer } from '@salesforce/source-deploy-retrieve';
 import { env } from '@salesforce/kit';
 import { PackageDir } from '@salesforce/schemas';
-import { PackageVersionMetadataDownloadOptions, PackageVersionMetadataDownloadResult } from '../interfaces';
+import {
+  PackageVersionMetadataDownloadOptions,
+  PackageVersionMetadataDownloadResult,
+  PackagingSObjects,
+} from '../interfaces';
 import { generatePackageAliasEntry, isPackageDirectoryEffectivelyEmpty } from '../utils/packageUtils';
 import { createPackageDirEntry } from './packageCreate';
 import { Package } from './package';
@@ -60,42 +64,14 @@ export async function retrievePackageVersionMetadata(
   const subscriberPackageVersionId =
     project.getPackageIdFromAlias(options.subscriberPackageVersionId) ?? options.subscriberPackageVersionId;
 
-  // Select only the columns this flow reads. Omitting the permission-gated DeveloperUsePkgZip
-  // keeps this query from throwing "No such column" before we can disambiguate the failure.
-  const queryOptions = {
-    whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
-    fields: ['Package2Id', 'ConvertedFromVersionId'] as Package2VersionFieldTypes,
-  };
-  let versionInfo;
-  try {
-    [versionInfo] = await PackageVersion.queryPackage2Version(connection, queryOptions);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    if (msg.includes("sObject type 'Package2Version' is not supported.")) {
-      throw messages.createError('packagingNotEnabledOnOrg');
-    }
-    throw e;
-  }
+  const versionInfo = await resolvePackage2Version(connection, subscriberPackageVersionId);
 
-  // Not in this Dev Hub: tell "doesn't exist anywhere" apart from "exists but not here".
-  if (!versionInfo) {
-    const exists = await subscriberPackageVersionExists(connection, subscriberPackageVersionId);
-    throw messages.createError(exists ? 'packageVersionNotInDevHub' : 'packageVersionNotFound', [
-      subscriberPackageVersionId,
-    ]);
-  }
+  // The package version exists in this Dev Hub, so now we fetch the download URL.
+  const developerUsePkgZipUrl = await fetchDeveloperUsePkgZipUrl(connection, subscriberPackageVersionId);
 
-  // Row exists; fetch the download URL separately. No URL means the user lacks the permission.
-  const developerUsePkgZipUrl = await getDeveloperUsePkgZipUrl(connection, subscriberPackageVersionId);
-  if (!developerUsePkgZipUrl) {
-    throw messages.createError('developerUsePkgZipFieldUnavailable');
-  }
-
-  const responseBase64 = await downloadDeveloperPackageZip(
-    connection,
-    developerUsePkgZipUrl,
-    subscriberPackageVersionId
-  );
+  const responseBase64 = await connection.tooling.request<string>(developerUsePkgZipUrl, {
+    encoding: 'base64',
+  });
   const buffer = Buffer.from(responseBase64, 'base64');
 
   let tree;
@@ -244,47 +220,71 @@ async function attemptToUpdateProjectJson(
   }
 }
 
-/** Download the package zip, mapping the servlet's late-stage access failures to actionable errors. */
-async function downloadDeveloperPackageZip(
+/**
+ * Query the Package2Version record for the given 04t, mapping a missing row to the right error: no
+ * packaging support on the org, not found anywhere, or found but not in this Dev Hub. Selects only
+ * columns any authenticated user can read, so the query always succeeds; selecting DeveloperUsePkgZip
+ * here (which requires the DownloadPackageVersionZips permission) would throw "No such column" for a
+ * user without that permission and mask those cases as a permission problem.
+ */
+async function resolvePackage2Version(
   connection: Connection,
-  developerUsePkgZipUrl: string,
   subscriberPackageVersionId: string
-): Promise<string> {
+): Promise<PackagingSObjects.Package2Version> {
+  const queryOptions = {
+    whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
+    fields: ['Package2Id', 'ConvertedFromVersionId'] as Package2VersionFieldTypes,
+  };
+  let versionInfo;
   try {
-    return await connection.tooling.request<string>(developerUsePkgZipUrl, { encoding: 'base64' });
+    [versionInfo] = await PackageVersion.queryPackage2Version(connection, queryOptions);
   } catch (e) {
-    const name = e instanceof Error ? e.name : '';
-    if (name === 'NOT_FOUND') {
-      throw messages.createError('packageVersionNotFound', [subscriberPackageVersionId]);
-    }
-    if (name === 'INSUFFICIENT_ACCESS' || name === 'INSUFFICIENT_ACCESS_OR_READONLY') {
-      throw messages.createError('packageVersionNotInDevHub', [subscriberPackageVersionId]);
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("sObject type 'Package2Version' is not supported.")) {
+      throw messages.createError('packagingNotEnabledOnOrg');
     }
     throw e;
   }
+
+  // No Package2Version row in this Dev Hub. Use SubscriberPackageVersion, a global view any
+  // authenticated user can query, to tell "doesn't exist anywhere" from "exists but not here".
+  if (!versionInfo) {
+    const exists = await subscriberPackageVersionExists(connection, subscriberPackageVersionId);
+    throw messages.createError(exists ? 'packageVersionNotInDevHub' : 'packageVersionNotFound', [
+      subscriberPackageVersionId,
+    ]);
+  }
+
+  return versionInfo;
 }
 
 /**
- * Fetch the permission-gated DeveloperUsePkgZip download URL on its own. Returns undefined when the
- * user can't access it, so both an empty value and its "No such column" error read the same.
+ * Fetch the DeveloperUsePkgZip download URL for a Package2Version row already confirmed to exist in
+ * this Dev Hub. Reading this column requires the DownloadPackageVersionZips permission, so once the
+ * row is known to exist, both a "No such column" error and a null value reliably mean the user lacks
+ * that permission.
  */
-async function getDeveloperUsePkgZipUrl(
-  connection: Connection,
-  subscriberPackageVersionId: string
-): Promise<string | undefined> {
+async function fetchDeveloperUsePkgZipUrl(connection: Connection, subscriberPackageVersionId: string): Promise<string> {
+  const queryOptions = {
+    whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
+    fields: ['DeveloperUsePkgZip'] as Package2VersionFieldTypes,
+  };
+  let versionInfo;
   try {
-    const [record] = await PackageVersion.queryPackage2Version(connection, {
-      whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
-      fields: ['DeveloperUsePkgZip'] as Package2VersionFieldTypes,
-    });
-    return record?.DeveloperUsePkgZip ?? undefined;
+    [versionInfo] = await PackageVersion.queryPackage2Version(connection, queryOptions);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     if (msg.includes("No such column 'DeveloperUsePkgZip' on entity 'Package2Version'")) {
-      return undefined;
+      throw messages.createError('developerUsePkgZipFieldUnavailable');
     }
     throw e;
   }
+
+  if (!versionInfo?.DeveloperUsePkgZip) {
+    throw messages.createError('developerUsePkgZipFieldUnavailable');
+  }
+
+  return versionInfo.DeveloperUsePkgZip;
 }
 
 /**

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -446,19 +446,4 @@ describe('Package Version Retrieve', () => {
       );
     }
   });
-
-  it('should select only the minimal fields (never the permission-gated DeveloperUsePkgZip) in the existence/disambiguation query', async () => {
-    await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);
-    const existenceCall = queryPackage2VersionStub.getCalls().find((call) => {
-      const opts = call.args[1] as { whereClause?: string; fields?: readonly string[] } | undefined;
-      return (
-        opts?.whereClause === `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` && !isZipUrlFetch(opts)
-      );
-    });
-    expect(existenceCall, 'expected an existence query call').to.not.be.undefined;
-    const existenceOpts = existenceCall?.args[1] as { fields?: readonly string[] } | undefined;
-    // Must select only the columns this flow reads, never the permission-gated DeveloperUsePkgZip.
-    expect(existenceOpts?.fields).to.deep.equal(['Package2Id', 'ConvertedFromVersionId']);
-    expect(existenceOpts?.fields).to.not.include('DeveloperUsePkgZip');
-  });
 });

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -261,6 +261,26 @@ describe('Package Version Retrieve', () => {
     }
   });
 
+  it('should throw packageVersionNotFound for a malformed 04t without querying', async () => {
+    const malformedId = '04tinvalid';
+
+    try {
+      await Package.downloadPackageVersionMetadata(
+        project,
+        { subscriberPackageVersionId: malformedId, destinationFolder },
+        connection
+      );
+      assert.fail('Expected test execution to raise an error');
+    } catch (e) {
+      const error = e as SfError;
+      expect(error.message).to.equal(
+        "Can't retrieve package metadata. We can't find the package version 04tinvalid. Verify that the 04t ID is correct and that the package version exists."
+      );
+      // The malformed ID must be rejected before any SOQL is issued, so no raw error can leak.
+      expect(queryPackage2VersionStub.called).to.equal(false);
+    }
+  });
+
   it('should throw packageVersionNotInDevHub when no Package2Version row exists but the SubscriberPackageVersion does', async () => {
     queryPackage2VersionStub.withArgs(connection, disambiguationQuery(packageVersionId2GP)).resolves([]);
     toolingQueryStub.resolves({ records: [{ Id: packageVersionId2GP }], done: true, totalSize: 1 });

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -25,6 +25,20 @@ import { Package } from '../../src/package/package';
 import { PackageVersion } from '../../src/package/packageVersion';
 import { PackageType } from '../../src/interfaces/packagingInterfacesAndType';
 
+// The retrieve flow issues two distinct queryPackage2Version calls that share a whereClause but
+// differ by their selected fields: a disambiguation query (non-gated columns) and a separate fetch
+// of the permission-gated DeveloperUsePkgZip URL. Match each by its field list.
+const disambiguationQuery = (subscriberPackageVersionId: string): sinon.SinonMatcher =>
+  sinon.match({
+    whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
+    fields: ['Package2Id', 'ConvertedFromVersionId'],
+  });
+const zipUrlQuery = (subscriberPackageVersionId: string): sinon.SinonMatcher =>
+  sinon.match({
+    whereClause: `WHERE SubscriberPackageVersionId = '${subscriberPackageVersionId}'`,
+    fields: ['DeveloperUsePkgZip'],
+  });
+
 describe('Package Version Retrieve', () => {
   const $$ = instantiateContext();
   const testOrg = new MockTestOrgData();
@@ -113,21 +127,6 @@ describe('Package Version Retrieve', () => {
   let getPackageDataStub: sinon.SinonStub;
   let toolingQueryStub: sinon.SinonStub;
 
-  // The retrieve flow issues two Package2Version queries: an existence query and a separate
-  // DeveloperUsePkgZip fetch. These matchers let tests control each independently.
-  const isZipUrlFetch = (opts?: { fields?: readonly string[] }): boolean =>
-    Array.isArray(opts?.fields) && opts?.fields.length === 1 && opts?.fields[0] === 'DeveloperUsePkgZip';
-  const existenceQuery = (id: string): sinon.SinonMatcher =>
-    sinon.match(
-      (opts: { whereClause?: string; fields?: readonly string[] }) =>
-        opts?.whereClause === `WHERE SubscriberPackageVersionId = '${id}'` && !isZipUrlFetch(opts)
-    );
-  const zipUrlQuery = (id: string): sinon.SinonMatcher =>
-    sinon.match(
-      (opts: { whereClause?: string; fields?: readonly string[] }) =>
-        opts?.whereClause === `WHERE SubscriberPackageVersionId = '${id}'` && isZipUrlFetch(opts)
-    );
-
   beforeEach(async () => {
     $$.inProject(true);
     project = SfProject.getInstance();
@@ -155,12 +154,7 @@ describe('Package Version Retrieve', () => {
     toolingQueryStub.resolves({ records: [{ Id: packageVersionId2GP }], done: true, totalSize: 1 });
 
     queryPackage2VersionStub = $$.SANDBOX.stub(PackageVersion, 'queryPackage2Version');
-    // Existence/disambiguation query (DeveloperUsePkgZip excluded) returns the row.
-    queryPackage2VersionStub.withArgs(connection, existenceQuery(packageVersionId2GP)).resolves([mockPackage2Version]);
-    // Targeted DeveloperUsePkgZip fetch returns the download URL.
-    queryPackage2VersionStub
-      .withArgs(connection, zipUrlQuery(packageVersionId2GP))
-      .resolves([{ DeveloperUsePkgZip: metadataZipURL2GP }]);
+    queryPackage2VersionStub.resolves([mockPackage2Version]);
 
     $$.SANDBOX.stub(packageUtils, 'generatePackageAliasEntry').resolves([
       `${packageName}@0.1.0-1-main`,
@@ -236,7 +230,7 @@ describe('Package Version Retrieve', () => {
 
   it('should not add a packageDirectory entry to sfdx-project.json after retrieving a managed 1GP version', async () => {
     // For 1GP packages, queryPackage2Version returns empty array, which means no Package2Version found.
-    queryPackage2VersionStub.withArgs(connection, existenceQuery(packageVersionId1GP)).resolves([]);
+    queryPackage2VersionStub.withArgs(connection, disambiguationQuery(packageVersionId1GP)).resolves([]);
     // The SubscriberPackageVersion exists globally, so this resolves to "not in this Dev Hub".
     toolingQueryStub.resolves({ records: [{ Id: packageVersionId1GP }], done: true, totalSize: 1 });
 
@@ -252,7 +246,7 @@ describe('Package Version Retrieve', () => {
   });
 
   it('should throw packageVersionNotFound when no Package2Version row exists and the 04t is unknown', async () => {
-    queryPackage2VersionStub.withArgs(connection, existenceQuery(packageVersionId1GP)).resolves([]);
+    queryPackage2VersionStub.withArgs(connection, disambiguationQuery(packageVersionId1GP)).resolves([]);
     // No SubscriberPackageVersion either => the 04t doesn't exist anywhere.
     toolingQueryStub.resolves({ records: [], done: true, totalSize: 0 });
 
@@ -268,7 +262,7 @@ describe('Package Version Retrieve', () => {
   });
 
   it('should throw packageVersionNotInDevHub when no Package2Version row exists but the SubscriberPackageVersion does', async () => {
-    queryPackage2VersionStub.withArgs(connection, existenceQuery(packageVersionId2GP)).resolves([]);
+    queryPackage2VersionStub.withArgs(connection, disambiguationQuery(packageVersionId2GP)).resolves([]);
     toolingQueryStub.resolves({ records: [{ Id: packageVersionId2GP }], done: true, totalSize: 1 });
 
     try {
@@ -380,7 +374,7 @@ describe('Package Version Retrieve', () => {
   it('should throw the native-2GP "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is unset', async () => {
     $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
     queryPackage2VersionStub
-      .withArgs(connection, existenceQuery(packageVersionId2GP))
+      .withArgs(connection, disambiguationQuery(packageVersionId2GP))
       .resolves([{ ...mockPackage2Version, ConvertedFromVersionId: '' }]);
 
     try {
@@ -398,7 +392,7 @@ describe('Package Version Retrieve', () => {
   it('should throw the converted-2GP "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is set', async () => {
     $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
     queryPackage2VersionStub
-      .withArgs(connection, existenceQuery(packageVersionId2GP))
+      .withArgs(connection, disambiguationQuery(packageVersionId2GP))
       .resolves([{ ...mockPackage2Version, ConvertedFromVersionId: '04txx0000004HwAAAU' }]);
 
     try {
@@ -414,7 +408,7 @@ describe('Package Version Retrieve', () => {
   });
 
   it('should fail if the DeveloperUsePkgZip field value is empty for the user', async () => {
-    // Row exists, but the download URL comes back empty: the user lacks the permission.
+    // Row exists (disambiguation succeeds), but the gated URL query comes back empty: no permission.
     queryPackage2VersionStub
       .withArgs(connection, zipUrlQuery(packageVersionId2GP))
       .resolves([{ DeveloperUsePkgZip: undefined }]);

--- a/test/package/packageVersionMetadataRetrieve.test.ts
+++ b/test/package/packageVersionMetadataRetrieve.test.ts
@@ -111,6 +111,22 @@ describe('Package Version Retrieve', () => {
   let queryPackage2VersionStub: sinon.SinonStub;
   let requestMetadataZipStub: sinon.SinonStub;
   let getPackageDataStub: sinon.SinonStub;
+  let toolingQueryStub: sinon.SinonStub;
+
+  // The retrieve flow issues two Package2Version queries: an existence query and a separate
+  // DeveloperUsePkgZip fetch. These matchers let tests control each independently.
+  const isZipUrlFetch = (opts?: { fields?: readonly string[] }): boolean =>
+    Array.isArray(opts?.fields) && opts?.fields.length === 1 && opts?.fields[0] === 'DeveloperUsePkgZip';
+  const existenceQuery = (id: string): sinon.SinonMatcher =>
+    sinon.match(
+      (opts: { whereClause?: string; fields?: readonly string[] }) =>
+        opts?.whereClause === `WHERE SubscriberPackageVersionId = '${id}'` && !isZipUrlFetch(opts)
+    );
+  const zipUrlQuery = (id: string): sinon.SinonMatcher =>
+    sinon.match(
+      (opts: { whereClause?: string; fields?: readonly string[] }) =>
+        opts?.whereClause === `WHERE SubscriberPackageVersionId = '${id}'` && isZipUrlFetch(opts)
+    );
 
   beforeEach(async () => {
     $$.inProject(true);
@@ -133,10 +149,18 @@ describe('Package Version Retrieve', () => {
     requestMetadataZipStub.withArgs(metadataZipURL2GP, { encoding: 'base64' }).resolves(secondGenBytesBase64);
     requestMetadataZipStub.withArgs(metadataZipURL1GP, { encoding: 'base64' }).resolves(firstGenBytesBase64);
 
+    // SubscriberPackageVersion existence probe used to disambiguate retrieve failures.
+    // Default to "exists" so happy-path tests are unaffected; override per-test as needed.
+    toolingQueryStub = $$.SANDBOX.stub(connection.tooling, 'query');
+    toolingQueryStub.resolves({ records: [{ Id: packageVersionId2GP }], done: true, totalSize: 1 });
+
     queryPackage2VersionStub = $$.SANDBOX.stub(PackageVersion, 'queryPackage2Version');
+    // Existence/disambiguation query (DeveloperUsePkgZip excluded) returns the row.
+    queryPackage2VersionStub.withArgs(connection, existenceQuery(packageVersionId2GP)).resolves([mockPackage2Version]);
+    // Targeted DeveloperUsePkgZip fetch returns the download URL.
     queryPackage2VersionStub
-      .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
-      .resolves([mockPackage2Version]);
+      .withArgs(connection, zipUrlQuery(packageVersionId2GP))
+      .resolves([{ DeveloperUsePkgZip: metadataZipURL2GP }]);
 
     $$.SANDBOX.stub(packageUtils, 'generatePackageAliasEntry').resolves([
       `${packageName}@0.1.0-1-main`,
@@ -211,10 +235,10 @@ describe('Package Version Retrieve', () => {
   });
 
   it('should not add a packageDirectory entry to sfdx-project.json after retrieving a managed 1GP version', async () => {
-    // For 1GP packages, queryPackage2Version returns empty array, which means no Package2Version found
-    queryPackage2VersionStub
-      .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId1GP}'` })
-      .resolves([]);
+    // For 1GP packages, queryPackage2Version returns empty array, which means no Package2Version found.
+    queryPackage2VersionStub.withArgs(connection, existenceQuery(packageVersionId1GP)).resolves([]);
+    // The SubscriberPackageVersion exists globally, so this resolves to "not in this Dev Hub".
+    toolingQueryStub.resolves({ records: [{ Id: packageVersionId1GP }], done: true, totalSize: 1 });
 
     try {
       await Package.downloadPackageVersionMetadata(project, downloadOptions1GP, connection);
@@ -222,7 +246,38 @@ describe('Package Version Retrieve', () => {
     } catch (e) {
       const error = e as SfError;
       expect(error.message).to.equal(
-        "Can't retrieve package metadata. To use this feature, you must first assign yourself the DownloadPackageVersionZips user permission. Then retry retrieving your package metadata."
+        "Can't retrieve package metadata. Package version 04txx00000000001gp isn't accessible from this Dev Hub org. You can only retrieve package metadata from the Dev Hub that created the package version. Verify that you specified the correct target Dev Hub."
+      );
+    }
+  });
+
+  it('should throw packageVersionNotFound when no Package2Version row exists and the 04t is unknown', async () => {
+    queryPackage2VersionStub.withArgs(connection, existenceQuery(packageVersionId1GP)).resolves([]);
+    // No SubscriberPackageVersion either => the 04t doesn't exist anywhere.
+    toolingQueryStub.resolves({ records: [], done: true, totalSize: 0 });
+
+    try {
+      await Package.downloadPackageVersionMetadata(project, downloadOptions1GP, connection);
+      assert.fail('Expected test execution to raise an error');
+    } catch (e) {
+      const error = e as SfError;
+      expect(error.message).to.equal(
+        "Can't retrieve package metadata. We can't find the package version 04txx00000000001gp. Verify that the 04t ID is correct and that the package version exists."
+      );
+    }
+  });
+
+  it('should throw packageVersionNotInDevHub when no Package2Version row exists but the SubscriberPackageVersion does', async () => {
+    queryPackage2VersionStub.withArgs(connection, existenceQuery(packageVersionId2GP)).resolves([]);
+    toolingQueryStub.resolves({ records: [{ Id: packageVersionId2GP }], done: true, totalSize: 1 });
+
+    try {
+      await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);
+      assert.fail('Expected test execution to raise an error');
+    } catch (e) {
+      const error = e as SfError;
+      expect(error.message).to.equal(
+        "Can't retrieve package metadata. Package version 04txx00000000002gp isn't accessible from this Dev Hub org. You can only retrieve package metadata from the Dev Hub that created the package version. Verify that you specified the correct target Dev Hub."
       );
     }
   });
@@ -325,7 +380,7 @@ describe('Package Version Retrieve', () => {
   it('should throw the native-2GP "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is unset', async () => {
     $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
     queryPackage2VersionStub
-      .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
+      .withArgs(connection, existenceQuery(packageVersionId2GP))
       .resolves([{ ...mockPackage2Version, ConvertedFromVersionId: '' }]);
 
     try {
@@ -343,7 +398,7 @@ describe('Package Version Retrieve', () => {
   it('should throw the converted-2GP "unretrievable dev zip" error when ZipTreeContainer is empty and ConvertedFromVersionId is set', async () => {
     $$.SANDBOX.stub(ZipTreeContainer, 'create').rejects(new Error('data length = 0'));
     queryPackage2VersionStub
-      .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
+      .withArgs(connection, existenceQuery(packageVersionId2GP))
       .resolves([{ ...mockPackage2Version, ConvertedFromVersionId: '04txx0000004HwAAAU' }]);
 
     try {
@@ -358,16 +413,11 @@ describe('Package Version Retrieve', () => {
     }
   });
 
-  it('should fail if the DeveloperUsePkgZip field is inaccessible to the user', async () => {
-    // Mock Package2Version without DeveloperUsePkgZip field to simulate field access issue
+  it('should fail if the DeveloperUsePkgZip field value is empty for the user', async () => {
+    // Row exists, but the download URL comes back empty: the user lacks the permission.
     queryPackage2VersionStub
-      .withArgs(connection, { whereClause: `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` })
-      .resolves([
-        {
-          ...mockPackage2Version,
-          DeveloperUsePkgZip: undefined, // This will cause the error
-        },
-      ]);
+      .withArgs(connection, zipUrlQuery(packageVersionId2GP))
+      .resolves([{ DeveloperUsePkgZip: undefined }]);
 
     try {
       await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);
@@ -378,5 +428,37 @@ describe('Package Version Retrieve', () => {
         "Can't retrieve package metadata. To use this feature, you must first assign yourself the DownloadPackageVersionZips user permission. Then retry retrieving your package metadata."
       );
     }
+  });
+
+  it('should fail if the DeveloperUsePkgZip column is not selectable for the user (No such column)', async () => {
+    // Selecting the gated column throws "No such column"; that must still surface the perm message.
+    queryPackage2VersionStub
+      .withArgs(connection, zipUrlQuery(packageVersionId2GP))
+      .rejects(new Error("No such column 'DeveloperUsePkgZip' on entity 'Package2Version'."));
+
+    try {
+      await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);
+      assert.fail('Expected test execution to raise an error');
+    } catch (e) {
+      const error = e as SfError;
+      expect(error.message).to.equal(
+        "Can't retrieve package metadata. To use this feature, you must first assign yourself the DownloadPackageVersionZips user permission. Then retry retrieving your package metadata."
+      );
+    }
+  });
+
+  it('should select only the minimal fields (never the permission-gated DeveloperUsePkgZip) in the existence/disambiguation query', async () => {
+    await Package.downloadPackageVersionMetadata(project, downloadOptions2GP, connection);
+    const existenceCall = queryPackage2VersionStub.getCalls().find((call) => {
+      const opts = call.args[1] as { whereClause?: string; fields?: readonly string[] } | undefined;
+      return (
+        opts?.whereClause === `WHERE SubscriberPackageVersionId = '${packageVersionId2GP}'` && !isZipUrlFetch(opts)
+      );
+    });
+    expect(existenceCall, 'expected an existence query call').to.not.be.undefined;
+    const existenceOpts = existenceCall?.args[1] as { fields?: readonly string[] } | undefined;
+    // Must select only the columns this flow reads, never the permission-gated DeveloperUsePkgZip.
+    expect(existenceOpts?.fields).to.deep.equal(['Package2Id', 'ConvertedFromVersionId']);
+    expect(existenceOpts?.fields).to.not.include('DeveloperUsePkgZip');
   });
 });


### PR DESCRIPTION
## What & Why

`sf package version retrieve` returned a single misleading error —
"you must first assign yourself the DownloadPackageVersionZips user permission" —
for three genuinely different failure modes:

1. The 04t ID doesn't exist anywhere.
2. The package version exists, but not in the targeted Dev Hub.
3. The user genuinely lacks the `DownloadPackageVersionZips` permission.

Only case 3 is a permission problem, so cases 1 and 2 sent users down a
fruitless perm-debugging detour. This splits the conflated check so each
case reports an actionable message.

@W-23089623@
Work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002cd3UWYAY/view

## How

The retrieve flow in `packageVersionRetrieve.ts` now runs two separate
`Package2Version` queries instead of one conflated lookup:

- **Disambiguation query** (`resolvePackage2Version`) selects only columns any
  authenticated user can read (`Package2Id`, `ConvertedFromVersionId`), so it
  never throws before we can classify the failure. If no row is visible in the
  running user's Dev Hub, it probes the global `SubscriberPackageVersion` view
  (queryable by any authenticated user) to tell **not-found**
  (`packageVersionNotFound`) apart from **exists-but-not-in-this-Dev-Hub**
  (`packageVersionNotInDevHub`).
- **Download-URL query** (`fetchDeveloperUsePkgZipUrl`) fetches the
  permission-controlled `DeveloperUsePkgZip` in an isolated query, run only
  after the row is confirmed present. Because existence is already
  established, both a "No such column" error and an empty value reliably mean
  the user lacks the permission → `developerUsePkgZipFieldUnavailable`
  (unchanged).

Selecting `DeveloperUsePkgZip` up front (as before) makes the query throw
"No such column" for a user without the permission, which is exactly what
masked cases 1 and 2 as a permission problem. Keeping it out of the
disambiguation query is what restores the three distinct messages.

Two new message keys added to `messages/package.md`:
`packageVersionNotFound`, `packageVersionNotInDevHub`.

## Tests

Updated/added unit coverage in `packageVersionMetadataRetrieve.test.ts`:
not-found, not-in-this-Dev-Hub, and missing-permission (empty value and
"No such column").
