### PR TITLE
fix: stop scoping LATEST dependency resolution to --branch flag @W-21617695@

### DIFF
--- a/src/package/packageVersionCreate.ts
+++ b/src/package/packageVersionCreate.ts
@@ -125,7 +125,31 @@ export class PackageVersionCreate {
     const branchString = !branch ? 'null' : `'${branch}'`;
 
     // resolve a build number keyword to an actual number, if needed
-    const resolvedBuildNumber = await this.resolveBuildNumber(versionNumber, dependency.packageId, branch);
+    let resolvedBuildNumber: string;
+    let effectiveBranchString = branchString;
+    try {
+      resolvedBuildNumber = await this.resolveBuildNumber(versionNumber, dependency.packageId, branch);
+    } catch (e) {
+      // when --branch was inherited (not set on the dependency itself) and LATEST resolution fails
+      // specifically because no version exists on that branch, fall back to null branch
+      if (
+        e instanceof Error &&
+        e.name === 'NoReleaseVersionFoundForBranchError' &&
+        dependency.branch === undefined &&
+        this.options.branch &&
+        buildNumber === BuildNumberToken.LATEST_BUILD_NUMBER_TOKEN
+      ) {
+        this.logger.info(
+          `Dependency ${dependency.package ?? dependency.packageId} has no versions on branch '${String(
+            branch
+          )}'. Falling back to unscoped (no branch) resolution.`
+        );
+        effectiveBranchString = 'null';
+        resolvedBuildNumber = await this.resolveBuildNumber(versionNumber, dependency.packageId, undefined);
+      } else {
+        throw e;
+      }
+    }
 
     // now that we have a full build number, query for the associated 04t.
     // because the build number may not be unique across versions, add in conditionals for
@@ -133,14 +157,14 @@ export class PackageVersionCreate {
     const branchOrReleasedCondition =
       buildNumber === BuildNumberToken.RELEASED_BUILD_NUMBER_TOKEN
         ? 'AND IsReleased = true'
-        : `AND Branch = ${branchString}`;
+        : `AND Branch = ${effectiveBranchString}`;
     const query = `SELECT SubscriberPackageVersionId FROM Package2Version WHERE Package2Id = '${dependency.packageId}' AND MajorVersion = ${versionNumber.major} AND MinorVersion = ${versionNumber.minor} AND PatchVersion = ${versionNumber.patch} AND BuildNumber = ${resolvedBuildNumber} ${branchOrReleasedCondition}`;
     const pkgVerQueryResult = await this.connection.tooling.query<PackagingSObjects.Package2Version>(query);
     const subRecords = pkgVerQueryResult.records;
     if (!subRecords || subRecords.length !== 1) {
       throw messages.createError('versionNumberNotFoundInDevHub', [
         dependency.packageId,
-        branchString,
+        effectiveBranchString,
         versionNumber.toString(),
         resolvedBuildNumber,
       ]);
@@ -155,7 +179,7 @@ export class PackageVersionCreate {
           messages.getMessage('buildNumberResolvedForLatest', [
             dependency.package,
             versionNumber.toString(),
-            branchString,
+            effectiveBranchString,
             dependency.subscriberPackageVersionId,
           ])
         );

--- a/test/package/packageVersionCreate.test.ts
+++ b/test/package/packageVersionCreate.test.ts
@@ -395,6 +395,57 @@ describe('Package Version Create', () => {
     expect(result).to.have.all.keys(expectedKeys);
   });
 
+  it('should fall back to null branch when --branch is set but dependency has no versions on that branch (LATEST)', async () => {
+    packageTypeQuery.restore();
+
+    const config = project.getSfProjectJson().getContents();
+    if (isDirWithDependencies(config.packageDirectories[1])) {
+      config.packageDirectories[1].dependencies[0].package = 'DEP';
+      config.packageDirectories[1].dependencies[0].versionNumber = '0.1.0.LATEST';
+    }
+    project.getSfProjectJson().set('packageDirectories', config.packageDirectories);
+    await project.getSfProjectJson().write();
+
+    // route tooling queries based on query content
+    // @ts-ignore - returning simplified promise instead of full Query type
+    packageTypeQuery = $$.SANDBOX.stub(connection.tooling, 'query').callsFake((query: string) => {
+      if (query.includes('ContainerOptions FROM Package2')) {
+        return Promise.resolve({ records: [{ ContainerOptions: 'Unlocked' }] });
+      }
+      if (query.includes('SELECT Id FROM Package2 WHERE')) {
+        return Promise.resolve({ records: [{ Id: '0Ho4J000000TNmPXXX' }] });
+      }
+      if (query.includes('MAX(BuildNumber)') && query.includes("Branch = 'feature-x'")) {
+        // no versions on the branch -> triggers fallback
+        return Promise.resolve({ records: [{ expr0: null }] });
+      }
+      if (query.includes('MAX(BuildNumber)') && query.includes('Branch = null')) {
+        // fallback: resolve from null branch
+        return Promise.resolve({ records: [{ expr0: 5 }] });
+      }
+      if (query.includes('SubscriberPackageVersionId')) {
+        return Promise.resolve({ records: [{ SubscriberPackageVersionId: '04t000000000001AAA' }] });
+      }
+      // default for any other query (e.g., ancestor)
+      return Promise.resolve({ records: [{ Id: '05i3i000000Gmj6XXX' }] });
+    });
+
+    const pvc = new PackageVersionCreate({
+      connection,
+      project,
+      branch: 'feature-x',
+      packageId,
+      skipancestorcheck: true,
+    });
+    stubConvert();
+
+    const result = await pvc.createPackageVersion();
+
+    // the package version create request should use 'feature-x' for the target package
+    expect(packageCreateStub.firstCall.args[1].Branch).to.equal('feature-x');
+    expect(result).to.have.all.keys(expectedKeys);
+  });
+
   it('should create the package version create request with language and API version >= 57.0', async () => {
     $$.SANDBOX.stub(connection, 'getApiVersion').returns('57.0');
     const pvc = new PackageVersionCreate({ connection, project, language: 'en_US', packageId });


### PR DESCRIPTION
## Summary
- When `--branch` is passed to `sf package version create`, LATEST dependency resolution now **falls back** to the null branch (main/released versions) if the dependency has no versions on the specified branch
- Previously, this would fail with `NoReleaseVersionFoundForBranchError` — now it gracefully resolves from the unscoped branch
- Dependencies that DO have versions on the branch still resolve from that branch (existing behavior preserved)
- Dependencies with an explicit `branch` in their config still use that branch (existing behavior preserved)

Fixes https://github.com/forcedotcom/cli/issues/3517

## Work Item
@W-21617695@: LATEST dependency resolution incorrectly scoped to --branch for all packages

## Proof of Work
- Tests: 275 passing, 0 failing
- Lint: clean (0 errors)
- Type check: clean

## Test plan
- [ ] Run `sf package version create --branch <branch>` with dependencies using `LATEST` that don't have versions on the specified branch — should now succeed by falling back to null branch resolution
- [ ] Run `sf package version create --branch <branch>` with dependencies that DO have versions on the branch — should resolve LATEST from that branch (existing behavior)
- [ ] Run `sf package version create --branch <branch>` with dependencies that have an explicit `branch` in their config — should still resolve against that explicit branch
- [ ] Run `sf package version create` (no --branch flag) with `LATEST` dependencies — behavior unchanged (resolves against null branch)
- [ ] Run with dependency.branch set to empty string `''` — should resolve against null branch (existing behavior preserved)