### PR TITLE
fix: use SfError.actions (array) instead of action (string)-W-16447880

### DIFF
--- a/src/utils/packageUtils.ts
+++ b/src/utils/packageUtils.ts
@@ -107,13 +107,12 @@ export function validateIdNoThrow(idObj: Many<IdRegistryValue>, value: string): 
 
 // applies actions to common package errors
 // eslint-disable-next-line complexity
-export function applyErrorAction(err: Error & { action?: string }): Error {
-  // append when actions already exist
-  const actions = [];
+export function applyErrorAction(err: Error | SfError): Error {
+  const actions: string[] = [];
 
   // include existing actions
-  if (err.action) {
-    actions.push(err.action);
+  if (err instanceof SfError && err.actions?.length) {
+    actions.push(...err.actions);
   }
 
   // TODO: (need to get with packaging team on this)
@@ -157,7 +156,11 @@ export function applyErrorAction(err: Error & { action?: string }): Error {
   }
 
   if (actions.length > 0) {
-    err['action'] = actions.join('\n');
+    if (err instanceof SfError) {
+      err.actions = actions;
+    } else {
+      (err as SfError).actions = actions;
+    }
   }
 
   return err;

--- a/test/utils/packageUtils.test.ts
+++ b/test/utils/packageUtils.test.ts
@@ -19,7 +19,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { assert, expect } from 'chai';
 import { instantiateContext, MockTestOrgData, restoreContext, stubContext } from '@salesforce/core/testSetup';
-import { SfProject } from '@salesforce/core';
+import { SfError, SfProject } from '@salesforce/core';
 import type { SaveError } from '@jsforce/jsforce-node';
 import { Duration } from '@salesforce/kit';
 import JSZIP from 'jszip';
@@ -259,12 +259,19 @@ describe('packageUtils', () => {
 
   describe('applyErrorAction', () => {
     describe('INVALID_TYPE', () => {
-      it('should modify error message if packaging is not enabled', () => {
-        const error = new Error() as Error & { action: string | undefined };
-        error.name = 'INVALID_TYPE';
-        error.message = "sObject type 'Package2Version' is not supported";
-        const result = applyErrorAction(error) as Error & { action: string | undefined };
-        expect(result.action).to.be.include('Packaging is not enabled on this org.');
+      it('should set actions on the error when packaging is not enabled', () => {
+        const error = new SfError("sObject type 'Package2Version' is not supported", 'INVALID_TYPE');
+        const result = applyErrorAction(error) as SfError;
+        expect(result.actions).to.be.an('array');
+        expect(result.actions?.join('\n')).to.include('Packaging is not enabled on this org.');
+      });
+
+      it('should preserve existing actions', () => {
+        const error = new SfError("sObject type 'Package2Version' is not supported", 'INVALID_TYPE');
+        error.actions = ['Existing action'];
+        const result = applyErrorAction(error) as SfError;
+        expect(result.actions).to.include('Existing action');
+        expect(result.actions?.join('\n')).to.include('Packaging is not enabled on this org.');
       });
     });
   });


### PR DESCRIPTION
 **Summary**
  
  - Fixed `applyErrorAction` in `packageUtils.ts` to set `SfError.actions` (string array) instead of err['action'] (string), which the CLI framework
  ignores
  - Preserves any existing actions already set on the error before appending new ones
  - Updated unit test to validate actions on the SfError object itself, not just the function return value
  
**Test plan**

  - [x] Unit tests pass (24/24) — validates actions are set as array and existing actions are preserved
  - [x] Direct library test confirms result.actions is a string[] and result.action is undefined
  - [x] E2E manual test: sf package installed list with a simulated INVALID_TYPE error renders "Try this:" in human output and "actions": [...]
  in --json output

Screenshot with `--json` and `without --json`

<img width="1393" height="461" alt="Screenshot 2026-08-04 at 2 08 22 PM" src="https://github.com/user-attachments/assets/cfcae81a-3bca-4acc-9a39-7aa3aa592263" />


@W-16447880@