### PR TITLE
feat: add PackageTrustLink.unlink for trust link removal (W-23970577)

### DIFF
--- a/messages/package_trust_link.md
+++ b/messages/package_trust_link.md
@@ -5,3 +5,7 @@ The Verified Org ID %s isn't valid. Specify a valid organization ID (starts with
 # trustLinkAlreadyExists
 
 This org already has a trust link to Verified Org %s with status '%s'. An org can have only one trust link at a time; delete the existing trust link before requesting a new one.
+
+# trustLinkNotFound
+
+This org has no trust link to remove; it's already in the Not Linked state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/packaging",
-  "version": "5.0.9-spi-dev.0",
+  "version": "5.0.9-spi.0",
   "description": "Packaging library for the Salesforce packaging platform",
   "main": "lib/exported",
   "types": "lib/exported.d.ts",

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -225,6 +225,17 @@ export type PackageTrustLinkRequestResult = {
   Status: string;
 };
 
+export type PackageTrustLinkUnlinkResult = {
+  // Whether an existing trust link was found and removed. false when the org was already Not Linked.
+  removed: boolean;
+  // Id of the removed trust link record, when one existed.
+  LinkRequestId?: string;
+  // Org ID of the Verified PBO the removed trust link pointed to, when one existed.
+  VerifiedOrgId?: string;
+  // State of the trust link at the time it was removed, when one existed.
+  Status?: string;
+};
+
 export type PackagePushRequestReportQueryOptions = {
   packagePushRequestId: string;
 };

--- a/src/package/packageTrustLink.ts
+++ b/src/package/packageTrustLink.ts
@@ -15,7 +15,11 @@
  */
 import type { Schema } from '@jsforce/jsforce-node';
 import { Connection, Messages, trimTo15, validateSalesforceId } from '@salesforce/core';
-import { PackageTrustLinkRequestOptions, PackageTrustLinkRequestResult } from '../interfaces';
+import {
+  PackageTrustLinkRequestOptions,
+  PackageTrustLinkRequestResult,
+  PackageTrustLinkUnlinkResult,
+} from '../interfaces';
 import { combineSaveErrors } from '../utils/packageUtils';
 
 Messages.importMessagesDirectory(__dirname);
@@ -80,6 +84,39 @@ export class PackageTrustLink {
       LinkRequestId: createResult.id,
       VerifiedOrgId: verifiedOrgId,
       Status: 'Pending',
+    };
+  }
+
+  /**
+   * Clear the connected authoring org's Public Secure (VerifiedDev) trust link, returning it to the
+   * `Not Linked` state.
+   *
+   * Deletes the authoring org's single trust relationship regardless of its current status. This is
+   * the developer/authoring-org side operation used both to abandon a request and to retry after a
+   * decline (unlink, then request again). It is idempotent: if the org has no trust link, it reports
+   * `removed: false` rather than erroring.
+   *
+   * @param connection - Connection to the authoring org (the 1GP namespace org or 2GP Dev Hub).
+   * @returns whether a link was removed and, when one existed, its Id, verified org ID, and status.
+   */
+  public static async unlink(connection: Connection): Promise<PackageTrustLinkUnlinkResult> {
+    // An authoring org holds at most one trust relationship, and the Tooling API query runs against
+    // the connected org (AuthoringOrg is server-set), so this returns that org's own link if any.
+    const existing = await queryExistingTrustLink(connection);
+    if (!existing) {
+      return { removed: false };
+    }
+
+    const deleteResult = await connection.tooling.sobject(TRUST_LINK_SOBJECT).destroy(existing.Id);
+    if (!deleteResult.success) {
+      throw combineSaveErrors(TRUST_LINK_SOBJECT, 'delete', deleteResult.errors);
+    }
+
+    return {
+      removed: true,
+      LinkRequestId: existing.Id,
+      VerifiedOrgId: existing.VerifiedOrg,
+      Status: existing.Status,
     };
   }
 }

--- a/test/package/packageTrustLink.test.ts
+++ b/test/package/packageTrustLink.test.ts
@@ -24,17 +24,19 @@ const trustLinkId = '2vtxx0000000001AAA';
 
 const createConnection = ({
   create = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] }),
+  destroy = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] }),
   autoFetchQuery = sinon.stub().resolves({ records: [] }),
   getApiVersion = sinon.stub().returns('64.0'),
 }: {
   create?: sinon.SinonStub;
+  destroy?: sinon.SinonStub;
   autoFetchQuery?: sinon.SinonStub;
   getApiVersion?: sinon.SinonStub;
 } = {}) =>
   ({
     autoFetchQuery,
     getApiVersion,
-    tooling: { create },
+    tooling: { create, sobject: sinon.stub().returns({ destroy }) },
   } as unknown as Connection);
 
 describe('PackageTrustLink', () => {
@@ -117,6 +119,70 @@ describe('PackageTrustLink', () => {
       } catch (err) {
         expect((err as Error).message).to.contain('DUPLICATE_VALUE');
         expect((err as Error).message).to.contain('Trust link already exists');
+      }
+    });
+  });
+
+  describe('unlink', () => {
+    it('removes the existing trust link and returns its details', async () => {
+      const autoFetchQuery = sinon
+        .stub()
+        .resolves({ records: [{ Id: trustLinkId, VerifiedOrg: verifiedOrgId15, Status: 'Pending' }] });
+      const destroy = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] });
+      const connection = createConnection({ autoFetchQuery, destroy });
+
+      const result = await PackageTrustLink.unlink(connection);
+
+      expect(result).to.deep.equal({
+        removed: true,
+        LinkRequestId: trustLinkId,
+        VerifiedOrgId: verifiedOrgId15,
+        Status: 'Pending',
+      });
+      expect(destroy.calledOnceWithExactly(trustLinkId)).to.equal(true);
+    });
+
+    it('removes a link in any status, e.g. Declined (retry-after-decline flow)', async () => {
+      const autoFetchQuery = sinon
+        .stub()
+        .resolves({ records: [{ Id: trustLinkId, VerifiedOrg: verifiedOrgId15, Status: 'Declined' }] });
+      const destroy = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] });
+      const connection = createConnection({ autoFetchQuery, destroy });
+
+      const result = await PackageTrustLink.unlink(connection);
+
+      expect(result.removed).to.equal(true);
+      expect(result.Status).to.equal('Declined');
+      expect(destroy.calledOnce).to.equal(true);
+    });
+
+    it('is idempotent: reports removed=false when the org is already Not Linked', async () => {
+      const autoFetchQuery = sinon.stub().resolves({ records: [] });
+      const destroy = sinon.stub();
+      const connection = createConnection({ autoFetchQuery, destroy });
+
+      const result = await PackageTrustLink.unlink(connection);
+
+      expect(result).to.deep.equal({ removed: false });
+      expect(destroy.called).to.equal(false);
+    });
+
+    it('surfaces Tooling API delete errors', async () => {
+      const autoFetchQuery = sinon
+        .stub()
+        .resolves({ records: [{ Id: trustLinkId, VerifiedOrg: verifiedOrgId15, Status: 'Pending' }] });
+      const destroy = sinon.stub().resolves({
+        success: false,
+        errors: [{ errorCode: 'INSUFFICIENT_ACCESS', message: 'no delete access', fields: [] }],
+      });
+      const connection = createConnection({ autoFetchQuery, destroy });
+
+      try {
+        await PackageTrustLink.unlink(connection);
+        expect.fail('expected the Tooling API delete error');
+      } catch (err) {
+        expect((err as Error).message).to.contain('INSUFFICIENT_ACCESS');
+        expect((err as Error).message).to.contain('no delete access');
       }
     });
   });


### PR DESCRIPTION
## What & Why

Implements **W-23970577 — [SPI] [L][CLI] Implement CLI for Public Secure management (link/unlink)** in the packaging library: the `unlink` half of the trust-link lifecycle.

`PackageTrustLink.unlink(connection)` clears an authoring org's Public Secure (VerifiedDev) trust link, returning it to the **Not Linked** state — regardless of the current state (Pending, Linked, or Declined). This backs the plugin's `sf package trust link unlink` command (in a separate plugin-packaging PR) and enables the retry-after-decline flow (unlink → request again).

## Behavior

- Looks up the connected org's single trust link via the Tooling API (`PkgVrfyAuthOrgTrustRela`). An authoring org holds at most one link, and the query is already scoped to the connected org, so no `WHERE` filter is needed.
- If a link exists, deletes it via `connection.tooling.sobject(...).destroy(id)` and returns `{ removed: true, LinkRequestId, VerifiedOrgId, Status }` with the details of the removed link.
- If no link exists, it's an idempotent no-op returning `{ removed: false }` — the org is already Not Linked.
- Surfaces Tooling API delete errors via `combineSaveErrors`.

## Changes

- `src/package/packageTrustLink.ts` — add `unlink` static method
- `src/interfaces/packagingInterfacesAndType.ts` — add `PackageTrustLinkUnlinkResult` type
- `messages/package_trust_link.md` — add `trustLinkNotFound` message
- `test/package/packageTrustLink.test.ts` — 4 new unit tests (removes + returns details; removes in any status incl. Declined; idempotent when Not Linked; surfaces delete errors)

## Testing

`yarn mocha test/package/packageTrustLink.test.ts` → 9 passing (5 request + 4 unlink).
