### PR TITLE
feat: add PackageTrustLink approval support

### DIFF
--- a/messages/package_trust_link.md
+++ b/messages/package_trust_link.md
@@ -18,6 +18,22 @@ Unable to determine the target org ID from the current connection.
 
 The status %s is invalid. Valid values are: pending, approved, declined, revoked.
 
+# exactlyOneApproveSelector
+
+Specify exactly one trust link selector: a request ID or an authoring org ID.
+
+# invalidTrustLinkRequestId
+
+The trust link request ID %s isn't valid. Specify a valid 15- or 18-character Salesforce ID and retry the command.
+
+# invalidAuthoringOrgId
+
+The Authoring Org ID %s isn't valid. Specify a valid organization ID (starts with 00D and is 15 or 18 characters) and retry the command.
+
+# pendingTrustLinkNotFound
+
+No pending trust link request matching %s was found for this Verified Org. Run "sf package trust link list --status pending" to review pending requests.
+
 # trustLinkNotFound
 
 This org has no trust link to remove; it's already in the Not Linked state.

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -260,6 +260,18 @@ export type PackageTrustLinkRecord = {
   RevokedDate: string | null;
 };
 
+export type PackageTrustLinkApproveOptions = {
+  requestId?: string;
+  authoringOrgId?: string;
+};
+
+export type PackageTrustLinkApproveResult = {
+  LinkRequestId: string;
+  AuthoringOrgId: string;
+  VerifiedOrgId: string;
+  Status: 'Accepted';
+};
+
 export type PackageTrustLinkUnlinkResult = {
   // Whether an existing trust link was found and removed. false when the org was already Not Linked.
   removed: boolean;

--- a/src/package/packageTrustLink.ts
+++ b/src/package/packageTrustLink.ts
@@ -16,6 +16,8 @@
 import type { Schema } from '@jsforce/jsforce-node';
 import { Connection, Messages, trimTo15, validateSalesforceId } from '@salesforce/core';
 import {
+  PackageTrustLinkApproveOptions,
+  PackageTrustLinkApproveResult,
   PackageTrustLinkListStatusFilter,
   PackageTrustLinkRecord,
   PackageTrustLinkRequestOptions,
@@ -43,6 +45,10 @@ const STATUS_FILTER_TO_API: Record<PackageTrustLinkListStatusFilter, PackageTrus
 };
 
 type PackageTrustLinkQueryRecord = PackageTrustLinkRecord & Schema;
+type PackageTrustLinkApproveRecord = Pick<PackageTrustLinkRecord, 'Id' | 'AuthoringOrg' | 'VerifiedOrg' | 'Status'> &
+  Schema;
+
+const SALESFORCE_ID_PATTERN = /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/;
 
 const isStatusFilter = (status: string): status is PackageTrustLinkListStatusFilter =>
   Object.prototype.hasOwnProperty.call(STATUS_FILTER_TO_API, status);
@@ -191,6 +197,81 @@ export class PackageTrustLink {
         RevokedDate: RevokedDate ?? null,
       })
     );
+  }
+
+  /**
+   * Approve a pending Public Secure (VerifiedDev) trust-link request for the connected Verified PBO.
+   *
+   * @param connection - Connection to the Verified Partner Business Org (PBO).
+   * @param options - Exactly one request ID or authoring org ID identifying the pending request.
+   * @returns the accepted trust relationship details.
+   */
+  public static async approve(
+    connection: Connection,
+    options: PackageTrustLinkApproveOptions
+  ): Promise<PackageTrustLinkApproveResult> {
+    if (Number(connection.getApiVersion()) < Number(MINIMUM_API_VERSION)) {
+      throw messages.createError('apiVersionTooLow', [MINIMUM_API_VERSION]);
+    }
+    if (Boolean(options.requestId) === Boolean(options.authoringOrgId)) {
+      throw messages.createError('exactlyOneApproveSelector');
+    }
+
+    const orgId = connection.getAuthInfoFields()?.orgId;
+    if (!orgId) {
+      throw messages.createError('missingOrgId');
+    }
+    const verifiedOrgId = trimTo15(orgId);
+
+    let selector: string;
+    let selectorValue: string;
+    if (options.requestId) {
+      if (
+        !options.requestId.startsWith('2vt') ||
+        !SALESFORCE_ID_PATTERN.test(options.requestId) ||
+        !validateSalesforceId(options.requestId)
+      ) {
+        throw messages.createError('invalidTrustLinkRequestId', [options.requestId]);
+      }
+      selector = `Id = '${options.requestId}'`;
+      selectorValue = options.requestId;
+    } else {
+      const authoringOrgId = options.authoringOrgId as string;
+      if (
+        !authoringOrgId.startsWith('00D') ||
+        !SALESFORCE_ID_PATTERN.test(authoringOrgId) ||
+        !validateSalesforceId(authoringOrgId)
+      ) {
+        throw messages.createError('invalidAuthoringOrgId', [authoringOrgId]);
+      }
+      selector = `AuthoringOrg = '${trimTo15(authoringOrgId)}'`;
+      selectorValue = authoringOrgId;
+    }
+
+    const query =
+      `SELECT Id, AuthoringOrg, VerifiedOrg, Status FROM ${TRUST_LINK_SOBJECT} ` +
+      `WHERE VerifiedOrg = '${verifiedOrgId}' AND OrganizationType = '${ORGANIZATION_TYPE_VERIFIED}' ` +
+      `AND AuthoringOrg != '${verifiedOrgId}' AND Status = 'Pending' AND ${selector} ORDER BY CreatedDate DESC LIMIT 1`;
+    const queryResult = await connection.autoFetchQuery<PackageTrustLinkApproveRecord>(query, { tooling: true });
+    const pendingRequest = queryResult.records?.[0];
+    if (!pendingRequest) {
+      throw messages.createError('pendingTrustLinkNotFound', [selectorValue]);
+    }
+
+    const updateResult = await connection.tooling.update(TRUST_LINK_SOBJECT, {
+      Id: pendingRequest.Id,
+      Status: 'Accepted',
+    });
+    if (!updateResult.success) {
+      throw combineSaveErrors(TRUST_LINK_SOBJECT, 'update', updateResult.errors);
+    }
+
+    return {
+      LinkRequestId: pendingRequest.Id,
+      AuthoringOrgId: pendingRequest.AuthoringOrg,
+      VerifiedOrgId: pendingRequest.VerifiedOrg,
+      Status: 'Accepted',
+    };
   }
 
   /**

--- a/src/package/packageTrustLink.ts
+++ b/src/package/packageTrustLink.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { Schema } from '@jsforce/jsforce-node';
-import { Connection, Messages, trimTo15 } from '@salesforce/core';
+import { Connection, Messages, trimTo15, validateSalesforceId } from '@salesforce/core';
 import {
   PackageTrustLinkApproveOptions,
   PackageTrustLinkApproveResult,
@@ -47,12 +47,6 @@ const STATUS_FILTER_TO_API: Record<PackageTrustLinkListStatusFilter, PackageTrus
 type PackageTrustLinkQueryRecord = PackageTrustLinkRecord & Schema;
 type PackageTrustLinkApproveRecord = Pick<PackageTrustLinkRecord, 'Id' | 'AuthoringOrg' | 'VerifiedOrg' | 'Status'> &
   Schema;
-
-// @salesforce/core's validateSalesforceId is unanchored (`/[a-zA-Z0-9]{15}/`) and only
-// checks length 15 or 18, so an 18-char value like `2vtxx0000000001' '` still passes.
-// Selectors are interpolated into Tooling SOQL, so the whole string must be a 15/18-char id.
-// packageUtils.validateId only checks prefix + length, not character set.
-const isExactSalesforceId = (value: string): boolean => /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/.test(value);
 
 const isStatusFilter = (status: string): status is PackageTrustLinkListStatusFilter =>
   Object.prototype.hasOwnProperty.call(STATUS_FILTER_TO_API, status);
@@ -95,7 +89,7 @@ export class PackageTrustLink {
     connection: Connection,
     options: PackageTrustLinkRequestOptions
   ): Promise<PackageTrustLinkRequestResult> {
-    if (!options.verifiedOrgId.startsWith('00D') || !isExactSalesforceId(options.verifiedOrgId)) {
+    if (!options.verifiedOrgId.startsWith('00D') || !validateSalesforceId(options.verifiedOrgId)) {
       throw messages.createError('invalidVerifiedOrgId', [options.verifiedOrgId]);
     }
     // VerifiedOrg is a TEXT field that core stores as a 15-char ID, so normalize before
@@ -230,14 +224,14 @@ export class PackageTrustLink {
     let selector: string;
     let selectorValue: string;
     if (options.requestId) {
-      if (!options.requestId.startsWith('2vt') || !isExactSalesforceId(options.requestId)) {
+      if (!options.requestId.startsWith('2vt') || !validateSalesforceId(options.requestId)) {
         throw messages.createError('invalidTrustLinkRequestId', [options.requestId]);
       }
       selector = `Id = '${options.requestId}'`;
       selectorValue = options.requestId;
     } else {
       const authoringOrgId = options.authoringOrgId as string;
-      if (!authoringOrgId.startsWith('00D') || !isExactSalesforceId(authoringOrgId)) {
+      if (!authoringOrgId.startsWith('00D') || !validateSalesforceId(authoringOrgId)) {
         throw messages.createError('invalidAuthoringOrgId', [authoringOrgId]);
       }
       selector = `AuthoringOrg = '${trimTo15(authoringOrgId)}'`;

--- a/src/package/packageTrustLink.ts
+++ b/src/package/packageTrustLink.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { Schema } from '@jsforce/jsforce-node';
-import { Connection, Messages, trimTo15, validateSalesforceId } from '@salesforce/core';
+import { Connection, Messages, trimTo15 } from '@salesforce/core';
 import {
   PackageTrustLinkApproveOptions,
   PackageTrustLinkApproveResult,
@@ -48,7 +48,11 @@ type PackageTrustLinkQueryRecord = PackageTrustLinkRecord & Schema;
 type PackageTrustLinkApproveRecord = Pick<PackageTrustLinkRecord, 'Id' | 'AuthoringOrg' | 'VerifiedOrg' | 'Status'> &
   Schema;
 
-const SALESFORCE_ID_PATTERN = /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/;
+// @salesforce/core's validateSalesforceId is unanchored (`/[a-zA-Z0-9]{15}/`) and only
+// checks length 15 or 18, so an 18-char value like `2vtxx0000000001' '` still passes.
+// Selectors are interpolated into Tooling SOQL, so the whole string must be a 15/18-char id.
+// packageUtils.validateId only checks prefix + length, not character set.
+const isExactSalesforceId = (value: string): boolean => /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/.test(value);
 
 const isStatusFilter = (status: string): status is PackageTrustLinkListStatusFilter =>
   Object.prototype.hasOwnProperty.call(STATUS_FILTER_TO_API, status);
@@ -91,7 +95,7 @@ export class PackageTrustLink {
     connection: Connection,
     options: PackageTrustLinkRequestOptions
   ): Promise<PackageTrustLinkRequestResult> {
-    if (!options.verifiedOrgId.startsWith('00D') || !validateSalesforceId(options.verifiedOrgId)) {
+    if (!options.verifiedOrgId.startsWith('00D') || !isExactSalesforceId(options.verifiedOrgId)) {
       throw messages.createError('invalidVerifiedOrgId', [options.verifiedOrgId]);
     }
     // VerifiedOrg is a TEXT field that core stores as a 15-char ID, so normalize before
@@ -226,22 +230,14 @@ export class PackageTrustLink {
     let selector: string;
     let selectorValue: string;
     if (options.requestId) {
-      if (
-        !options.requestId.startsWith('2vt') ||
-        !SALESFORCE_ID_PATTERN.test(options.requestId) ||
-        !validateSalesforceId(options.requestId)
-      ) {
+      if (!options.requestId.startsWith('2vt') || !isExactSalesforceId(options.requestId)) {
         throw messages.createError('invalidTrustLinkRequestId', [options.requestId]);
       }
       selector = `Id = '${options.requestId}'`;
       selectorValue = options.requestId;
     } else {
       const authoringOrgId = options.authoringOrgId as string;
-      if (
-        !authoringOrgId.startsWith('00D') ||
-        !SALESFORCE_ID_PATTERN.test(authoringOrgId) ||
-        !validateSalesforceId(authoringOrgId)
-      ) {
+      if (!authoringOrgId.startsWith('00D') || !isExactSalesforceId(authoringOrgId)) {
         throw messages.createError('invalidAuthoringOrgId', [authoringOrgId]);
       }
       selector = `AuthoringOrg = '${trimTo15(authoringOrgId)}'`;

--- a/test/package/packageTrustLink.test.ts
+++ b/test/package/packageTrustLink.test.ts
@@ -25,18 +25,23 @@ const trustLinkId = '2vtxx0000000001AAA';
 const createConnection = ({
   create = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] }),
   destroy = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] }),
+  update = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] }),
   autoFetchQuery = sinon.stub().resolves({ records: [] }),
   getApiVersion = sinon.stub().returns('64.0'),
+  orgId = verifiedOrgId18,
 }: {
   create?: sinon.SinonStub;
   destroy?: sinon.SinonStub;
+  update?: sinon.SinonStub;
   autoFetchQuery?: sinon.SinonStub;
   getApiVersion?: sinon.SinonStub;
+  orgId?: string;
 } = {}) =>
   ({
     autoFetchQuery,
     getApiVersion,
-    tooling: { create, sobject: sinon.stub().returns({ destroy }) },
+    getAuthInfoFields: sinon.stub().returns({ orgId }),
+    tooling: { create, update, sobject: sinon.stub().returns({ destroy }) },
   } as unknown as Connection);
 
 describe('PackageTrustLink', () => {
@@ -353,6 +358,179 @@ describe('PackageTrustLink', () => {
         expect.fail('Expected a missing org ID error');
       } catch (error) {
         expect((error as Error).message).to.contain('Unable to determine the target org ID');
+      }
+    });
+  });
+
+  describe('approve', () => {
+    const authoringOrgId15 = '00Dxx0000009zZZ';
+    const authoringOrgId18 = '00Dxx0000009zZZEAY';
+    const pendingRecord = {
+      Id: trustLinkId,
+      AuthoringOrg: authoringOrgId15,
+      VerifiedOrg: verifiedOrgId15,
+      Status: 'Pending',
+    };
+
+    it('approves a pending request selected by request ID', async () => {
+      const autoFetchQuery = sinon.stub().resolves({ records: [pendingRecord] });
+      const update = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] });
+      const connection = createConnection({
+        autoFetchQuery,
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      const result = await PackageTrustLink.approve(connection, { requestId: trustLinkId });
+
+      expect(result).to.deep.equal({
+        LinkRequestId: trustLinkId,
+        AuthoringOrgId: authoringOrgId15,
+        VerifiedOrgId: verifiedOrgId15,
+        Status: 'Accepted',
+      });
+      expect(autoFetchQuery.firstCall.args[0]).to.equal(
+        `SELECT Id, AuthoringOrg, VerifiedOrg, Status FROM PkgVrfyAuthOrgTrustRela WHERE VerifiedOrg = '${verifiedOrgId15}' AND OrganizationType = 'Verified' AND AuthoringOrg != '${verifiedOrgId15}' AND Status = 'Pending' AND Id = '${trustLinkId}' ORDER BY CreatedDate DESC LIMIT 1`
+      );
+      expect(autoFetchQuery.firstCall.args[1]).to.deep.equal({ tooling: true });
+      expect(update.calledOnceWithExactly('PkgVrfyAuthOrgTrustRela', { Id: trustLinkId, Status: 'Accepted' })).to.equal(
+        true
+      );
+    });
+
+    it('approves a pending request selected by authoring org', async () => {
+      const autoFetchQuery = sinon.stub().resolves({ records: [pendingRecord] });
+      const update = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] });
+      const connection = createConnection({
+        autoFetchQuery,
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      await PackageTrustLink.approve(connection, { authoringOrgId: authoringOrgId18 });
+
+      expect(autoFetchQuery.firstCall.args[0]).to.contain(`AND AuthoringOrg = '${authoringOrgId15}'`);
+      expect(update.calledOnce).to.equal(true);
+    });
+
+    it('rejects a request ID with the wrong entity prefix', async () => {
+      const connection = createConnection({ getApiVersion: sinon.stub().returns('68.0') });
+
+      try {
+        await PackageTrustLink.approve(connection, { requestId: verifiedOrgId18 });
+        expect.fail('expected request ID validation to fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain("isn't valid");
+      }
+    });
+
+    it('rejects non-alphanumeric characters in a request ID', async () => {
+      const connection = createConnection({ getApiVersion: sinon.stub().returns('68.0') });
+
+      try {
+        await PackageTrustLink.approve(connection, { requestId: "2vtxx0000000001' '" });
+        expect.fail('expected request ID validation to fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain("isn't valid");
+      }
+    });
+
+    it('rejects an invalid authoring org ID', async () => {
+      const connection = createConnection({ getApiVersion: sinon.stub().returns('68.0') });
+
+      try {
+        await PackageTrustLink.approve(connection, { authoringOrgId: '001xx0000009zZZ' });
+        expect.fail('expected authoring org ID validation to fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain("isn't valid");
+      }
+    });
+
+    it('requires API version 68.0 or later', async () => {
+      const connection = createConnection({ getApiVersion: sinon.stub().returns('67.0') });
+
+      try {
+        await PackageTrustLink.approve(connection, { requestId: trustLinkId });
+        expect.fail('expected API version validation to fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('API version 68.0 or later');
+      }
+    });
+
+    it('requires the connected verified org ID', async () => {
+      const connection = createConnection({
+        getApiVersion: sinon.stub().returns('68.0'),
+        orgId: '',
+      });
+
+      try {
+        await PackageTrustLink.approve(connection, { requestId: trustLinkId });
+        expect.fail('expected missing org ID validation to fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('Unable to determine the target org ID');
+      }
+    });
+
+    it('rejects an empty selector', async () => {
+      const connection = createConnection({ getApiVersion: sinon.stub().returns('68.0') });
+
+      try {
+        await PackageTrustLink.approve(connection, {});
+        expect.fail('expected exactly-one selector validation to fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('exactly one');
+      }
+    });
+
+    it('rejects multiple selectors', async () => {
+      const connection = createConnection({ getApiVersion: sinon.stub().returns('68.0') });
+
+      try {
+        await PackageTrustLink.approve(connection, {
+          requestId: trustLinkId,
+          authoringOrgId: authoringOrgId15,
+        });
+        expect.fail('expected exactly-one selector validation to fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('exactly one');
+      }
+    });
+
+    it('does not update when no pending request matches the connected verified org', async () => {
+      const update = sinon.stub();
+      const connection = createConnection({
+        autoFetchQuery: sinon.stub().resolves({ records: [] }),
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      try {
+        await PackageTrustLink.approve(connection, { requestId: trustLinkId });
+        expect.fail('expected a not-found error');
+      } catch (error) {
+        expect((error as Error).message).to.contain('No pending trust link request');
+      }
+      expect(update.called).to.equal(false);
+    });
+
+    it('surfaces Tooling API update errors', async () => {
+      const update = sinon.stub().resolves({
+        success: false,
+        id: trustLinkId,
+        errors: [{ errorCode: 'INSUFFICIENT_ACCESS', message: 'approval denied', fields: [] }],
+      });
+      const connection = createConnection({
+        autoFetchQuery: sinon.stub().resolves({ records: [pendingRecord] }),
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      try {
+        await PackageTrustLink.approve(connection, { requestId: trustLinkId });
+        expect.fail('expected the Tooling API update error');
+      } catch (error) {
+        expect((error as Error).message).to.contain('INSUFFICIENT_ACCESS');
+        expect((error as Error).message).to.contain('approval denied');
       }
     });
   });

--- a/test/package/packageTrustLink.test.ts
+++ b/test/package/packageTrustLink.test.ts
@@ -424,11 +424,11 @@ describe('PackageTrustLink', () => {
       }
     });
 
-    it('rejects non-alphanumeric characters in a request ID', async () => {
+    it('rejects a request ID that is not a Salesforce Id', async () => {
       const connection = createConnection({ getApiVersion: sinon.stub().returns('68.0') });
 
       try {
-        await PackageTrustLink.approve(connection, { requestId: "2vtxx0000000001' '" });
+        await PackageTrustLink.approve(connection, { requestId: '2vtxx000000000' });
         expect.fail('expected request ID validation to fail');
       } catch (error) {
         expect((error as Error).message).to.contain("isn't valid");


### PR DESCRIPTION
## Summary
- add `PackageTrustLink.approve` for PBO admins to accept pending VerifiedDev trust links
- support selection by trust-link request ID or authoring org ID, scoped to the connected verified org
- validate selectors and return actionable errors without mutating unmatched or non-pending links

## Test plan
- [x] `yarn test`
- [x] request-ID and authoring-org approval paths
- [x] selector, API-version, connected-org, not-found, and Tooling error coverage

## Companion CLI
- [salesforcecli/plugin-packaging#1277](https://github.com/salesforcecli/plugin-packaging/pull/1277)