### PR TITLE
feat: add PackageTrustLink deny and revoke support

### DIFF
--- a/messages/package_trust_link.md
+++ b/messages/package_trust_link.md
@@ -34,6 +34,10 @@ The Authoring Org ID %s isn't valid. Specify a valid organization ID (starts wit
 
 No pending trust link request matching %s was found for this Verified Org. Run "sf package trust link list --status pending" to review pending requests.
 
+# acceptedTrustLinkNotFound
+
+No accepted trust link matching %s was found for this Verified Org. Run "sf package trust link list --status approved" to review approved links.
+
 # trustLinkNotFound
 
 This org has no trust link to remove; it's already in the Not Linked state.

--- a/src/interfaces/packagingInterfacesAndType.ts
+++ b/src/interfaces/packagingInterfacesAndType.ts
@@ -260,16 +260,34 @@ export type PackageTrustLinkRecord = {
   RevokedDate: string | null;
 };
 
-export type PackageTrustLinkApproveOptions = {
+export type PackageTrustLinkSelectorOptions = {
   requestId?: string;
   authoringOrgId?: string;
 };
+
+export type PackageTrustLinkApproveOptions = PackageTrustLinkSelectorOptions;
+export type PackageTrustLinkDenyOptions = PackageTrustLinkSelectorOptions;
+export type PackageTrustLinkRevokeOptions = PackageTrustLinkSelectorOptions;
 
 export type PackageTrustLinkApproveResult = {
   LinkRequestId: string;
   AuthoringOrgId: string;
   VerifiedOrgId: string;
   Status: 'Accepted';
+};
+
+export type PackageTrustLinkDenyResult = {
+  LinkRequestId: string;
+  AuthoringOrgId: string;
+  VerifiedOrgId: string;
+  Status: 'Declined';
+};
+
+export type PackageTrustLinkRevokeResult = {
+  LinkRequestId: string;
+  AuthoringOrgId: string;
+  VerifiedOrgId: string;
+  Status: 'Revoked';
 };
 
 export type PackageTrustLinkUnlinkResult = {

--- a/src/package/packageTrustLink.ts
+++ b/src/package/packageTrustLink.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { Schema } from '@jsforce/jsforce-node';
-import { Connection, Messages, trimTo15, validateSalesforceId } from '@salesforce/core';
+import { Connection, Messages, trimTo15 } from '@salesforce/core';
 import {
   PackageTrustLinkApproveOptions,
   PackageTrustLinkApproveResult,
@@ -61,7 +61,11 @@ type InboundTrustMutationResult<S extends InboundTrustMutationStatus> = {
   Status: S;
 };
 
-const SALESFORCE_ID_PATTERN = /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/;
+// @salesforce/core's validateSalesforceId is unanchored (`/[a-zA-Z0-9]{15}/`) and only
+// checks length 15 or 18, so an 18-char value like `2vtxx0000000001' '` still passes.
+// Selectors are interpolated into Tooling SOQL, so the whole string must be a 15/18-char id.
+// packageUtils.validateId only checks prefix + length, not character set.
+const isExactSalesforceId = (value: string): boolean => /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/.test(value);
 
 const isStatusFilter = (status: string): status is PackageTrustLinkListStatusFilter =>
   Object.prototype.hasOwnProperty.call(STATUS_FILTER_TO_API, status);
@@ -104,7 +108,7 @@ export class PackageTrustLink {
     connection: Connection,
     options: PackageTrustLinkRequestOptions
   ): Promise<PackageTrustLinkRequestResult> {
-    if (!options.verifiedOrgId.startsWith('00D') || !validateSalesforceId(options.verifiedOrgId)) {
+    if (!options.verifiedOrgId.startsWith('00D') || !isExactSalesforceId(options.verifiedOrgId)) {
       throw messages.createError('invalidVerifiedOrgId', [options.verifiedOrgId]);
     }
     // VerifiedOrg is a TEXT field that core stores as a 15-char ID, so normalize before
@@ -317,22 +321,14 @@ async function updateInboundTrustLink<S extends InboundTrustMutationStatus>(
   let selector: string;
   let selectorValue: string;
   if (options.requestId) {
-    if (
-      !options.requestId.startsWith('2vt') ||
-      !SALESFORCE_ID_PATTERN.test(options.requestId) ||
-      !validateSalesforceId(options.requestId)
-    ) {
+    if (!options.requestId.startsWith('2vt') || !isExactSalesforceId(options.requestId)) {
       throw messages.createError('invalidTrustLinkRequestId', [options.requestId]);
     }
     selector = `Id = '${options.requestId}'`;
     selectorValue = options.requestId;
   } else {
     const authoringOrgId = options.authoringOrgId as string;
-    if (
-      !authoringOrgId.startsWith('00D') ||
-      !SALESFORCE_ID_PATTERN.test(authoringOrgId) ||
-      !validateSalesforceId(authoringOrgId)
-    ) {
+    if (!authoringOrgId.startsWith('00D') || !isExactSalesforceId(authoringOrgId)) {
       throw messages.createError('invalidAuthoringOrgId', [authoringOrgId]);
     }
     selector = `AuthoringOrg = '${trimTo15(authoringOrgId)}'`;

--- a/src/package/packageTrustLink.ts
+++ b/src/package/packageTrustLink.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import type { Schema } from '@jsforce/jsforce-node';
-import { Connection, Messages, trimTo15 } from '@salesforce/core';
+import { Connection, Messages, trimTo15, validateSalesforceId } from '@salesforce/core';
 import {
   PackageTrustLinkApproveOptions,
   PackageTrustLinkApproveResult,
@@ -61,12 +61,6 @@ type InboundTrustMutationResult<S extends InboundTrustMutationStatus> = {
   Status: S;
 };
 
-// @salesforce/core's validateSalesforceId is unanchored (`/[a-zA-Z0-9]{15}/`) and only
-// checks length 15 or 18, so an 18-char value like `2vtxx0000000001' '` still passes.
-// Selectors are interpolated into Tooling SOQL, so the whole string must be a 15/18-char id.
-// packageUtils.validateId only checks prefix + length, not character set.
-const isExactSalesforceId = (value: string): boolean => /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/.test(value);
-
 const isStatusFilter = (status: string): status is PackageTrustLinkListStatusFilter =>
   Object.prototype.hasOwnProperty.call(STATUS_FILTER_TO_API, status);
 
@@ -108,7 +102,7 @@ export class PackageTrustLink {
     connection: Connection,
     options: PackageTrustLinkRequestOptions
   ): Promise<PackageTrustLinkRequestResult> {
-    if (!options.verifiedOrgId.startsWith('00D') || !isExactSalesforceId(options.verifiedOrgId)) {
+    if (!options.verifiedOrgId.startsWith('00D') || !validateSalesforceId(options.verifiedOrgId)) {
       throw messages.createError('invalidVerifiedOrgId', [options.verifiedOrgId]);
     }
     // VerifiedOrg is a TEXT field that core stores as a 15-char ID, so normalize before
@@ -321,14 +315,14 @@ async function updateInboundTrustLink<S extends InboundTrustMutationStatus>(
   let selector: string;
   let selectorValue: string;
   if (options.requestId) {
-    if (!options.requestId.startsWith('2vt') || !isExactSalesforceId(options.requestId)) {
+    if (!options.requestId.startsWith('2vt') || !validateSalesforceId(options.requestId)) {
       throw messages.createError('invalidTrustLinkRequestId', [options.requestId]);
     }
     selector = `Id = '${options.requestId}'`;
     selectorValue = options.requestId;
   } else {
     const authoringOrgId = options.authoringOrgId as string;
-    if (!authoringOrgId.startsWith('00D') || !isExactSalesforceId(authoringOrgId)) {
+    if (!authoringOrgId.startsWith('00D') || !validateSalesforceId(authoringOrgId)) {
       throw messages.createError('invalidAuthoringOrgId', [authoringOrgId]);
     }
     selector = `AuthoringOrg = '${trimTo15(authoringOrgId)}'`;

--- a/src/package/packageTrustLink.ts
+++ b/src/package/packageTrustLink.ts
@@ -18,10 +18,15 @@ import { Connection, Messages, trimTo15, validateSalesforceId } from '@salesforc
 import {
   PackageTrustLinkApproveOptions,
   PackageTrustLinkApproveResult,
+  PackageTrustLinkDenyOptions,
+  PackageTrustLinkDenyResult,
   PackageTrustLinkListStatusFilter,
   PackageTrustLinkRecord,
   PackageTrustLinkRequestOptions,
   PackageTrustLinkRequestResult,
+  PackageTrustLinkRevokeOptions,
+  PackageTrustLinkRevokeResult,
+  PackageTrustLinkSelectorOptions,
   PackageTrustLinkStatus,
   PackageTrustLinkStatusResult,
   PackageTrustLinkUnlinkResult,
@@ -45,8 +50,16 @@ const STATUS_FILTER_TO_API: Record<PackageTrustLinkListStatusFilter, PackageTrus
 };
 
 type PackageTrustLinkQueryRecord = PackageTrustLinkRecord & Schema;
-type PackageTrustLinkApproveRecord = Pick<PackageTrustLinkRecord, 'Id' | 'AuthoringOrg' | 'VerifiedOrg' | 'Status'> &
+type PackageTrustLinkMutationRecord = Pick<PackageTrustLinkRecord, 'Id' | 'AuthoringOrg' | 'VerifiedOrg' | 'Status'> &
   Schema;
+
+type InboundTrustMutationStatus = 'Accepted' | 'Declined' | 'Revoked';
+type InboundTrustMutationResult<S extends InboundTrustMutationStatus> = {
+  LinkRequestId: string;
+  AuthoringOrgId: string;
+  VerifiedOrgId: string;
+  Status: S;
+};
 
 const SALESFORCE_ID_PATTERN = /^[a-zA-Z0-9]{15}([a-zA-Z0-9]{3})?$/;
 
@@ -210,68 +223,41 @@ export class PackageTrustLink {
     connection: Connection,
     options: PackageTrustLinkApproveOptions
   ): Promise<PackageTrustLinkApproveResult> {
-    if (Number(connection.getApiVersion()) < Number(MINIMUM_API_VERSION)) {
-      throw messages.createError('apiVersionTooLow', [MINIMUM_API_VERSION]);
-    }
-    if (Boolean(options.requestId) === Boolean(options.authoringOrgId)) {
-      throw messages.createError('exactlyOneApproveSelector');
-    }
+    return updateInboundTrustLink(connection, options, 'Pending', 'Accepted', 'pendingTrustLinkNotFound');
+  }
 
-    const orgId = connection.getAuthInfoFields()?.orgId;
-    if (!orgId) {
-      throw messages.createError('missingOrgId');
-    }
-    const verifiedOrgId = trimTo15(orgId);
+  /**
+   * Deny a pending Public Secure (VerifiedDev) trust-link request for the connected Verified PBO.
+   *
+   * Core only allows Pending → Declined on the verified-org copy. This does not delete the
+   * relationship; the authoring org can unlink and request again.
+   *
+   * @param connection - Connection to the Verified Partner Business Org (PBO).
+   * @param options - Exactly one request ID or authoring org ID identifying the pending request.
+   * @returns the declined trust relationship details.
+   */
+  public static async deny(
+    connection: Connection,
+    options: PackageTrustLinkDenyOptions
+  ): Promise<PackageTrustLinkDenyResult> {
+    return updateInboundTrustLink(connection, options, 'Pending', 'Declined', 'pendingTrustLinkNotFound');
+  }
 
-    let selector: string;
-    let selectorValue: string;
-    if (options.requestId) {
-      if (
-        !options.requestId.startsWith('2vt') ||
-        !SALESFORCE_ID_PATTERN.test(options.requestId) ||
-        !validateSalesforceId(options.requestId)
-      ) {
-        throw messages.createError('invalidTrustLinkRequestId', [options.requestId]);
-      }
-      selector = `Id = '${options.requestId}'`;
-      selectorValue = options.requestId;
-    } else {
-      const authoringOrgId = options.authoringOrgId as string;
-      if (
-        !authoringOrgId.startsWith('00D') ||
-        !SALESFORCE_ID_PATTERN.test(authoringOrgId) ||
-        !validateSalesforceId(authoringOrgId)
-      ) {
-        throw messages.createError('invalidAuthoringOrgId', [authoringOrgId]);
-      }
-      selector = `AuthoringOrg = '${trimTo15(authoringOrgId)}'`;
-      selectorValue = authoringOrgId;
-    }
-
-    const query =
-      `SELECT Id, AuthoringOrg, VerifiedOrg, Status FROM ${TRUST_LINK_SOBJECT} ` +
-      `WHERE VerifiedOrg = '${verifiedOrgId}' AND OrganizationType = '${ORGANIZATION_TYPE_VERIFIED}' ` +
-      `AND AuthoringOrg != '${verifiedOrgId}' AND Status = 'Pending' AND ${selector} ORDER BY CreatedDate DESC LIMIT 1`;
-    const queryResult = await connection.autoFetchQuery<PackageTrustLinkApproveRecord>(query, { tooling: true });
-    const pendingRequest = queryResult.records?.[0];
-    if (!pendingRequest) {
-      throw messages.createError('pendingTrustLinkNotFound', [selectorValue]);
-    }
-
-    const updateResult = await connection.tooling.update(TRUST_LINK_SOBJECT, {
-      Id: pendingRequest.Id,
-      Status: 'Accepted',
-    });
-    if (!updateResult.success) {
-      throw combineSaveErrors(TRUST_LINK_SOBJECT, 'update', updateResult.errors);
-    }
-
-    return {
-      LinkRequestId: pendingRequest.Id,
-      AuthoringOrgId: pendingRequest.AuthoringOrg,
-      VerifiedOrgId: pendingRequest.VerifiedOrg,
-      Status: 'Accepted',
-    };
+  /**
+   * Revoke an accepted Public Secure (VerifiedDev) trust link for the connected Verified PBO.
+   *
+   * Core only allows Accepted → Revoked on the verified-org copy. Pending requests must be
+   * denied instead; already-declined or already-revoked links cannot be revoked again.
+   *
+   * @param connection - Connection to the Verified Partner Business Org (PBO).
+   * @param options - Exactly one request ID or authoring org ID identifying the accepted link.
+   * @returns the revoked trust relationship details.
+   */
+  public static async revoke(
+    connection: Connection,
+    options: PackageTrustLinkRevokeOptions
+  ): Promise<PackageTrustLinkRevokeResult> {
+    return updateInboundTrustLink(connection, options, 'Accepted', 'Revoked', 'acceptedTrustLinkNotFound');
   }
 
   /**
@@ -306,6 +292,77 @@ export class PackageTrustLink {
       Status: existing.Status,
     };
   }
+}
+
+async function updateInboundTrustLink<S extends InboundTrustMutationStatus>(
+  connection: Connection,
+  options: PackageTrustLinkSelectorOptions,
+  requiredStatus: PackageTrustLinkStatus,
+  nextStatus: S,
+  notFoundMessage: 'pendingTrustLinkNotFound' | 'acceptedTrustLinkNotFound'
+): Promise<InboundTrustMutationResult<S>> {
+  if (Number(connection.getApiVersion()) < Number(MINIMUM_API_VERSION)) {
+    throw messages.createError('apiVersionTooLow', [MINIMUM_API_VERSION]);
+  }
+  if (Boolean(options.requestId) === Boolean(options.authoringOrgId)) {
+    throw messages.createError('exactlyOneApproveSelector');
+  }
+
+  const orgId = connection.getAuthInfoFields()?.orgId;
+  if (!orgId) {
+    throw messages.createError('missingOrgId');
+  }
+  const verifiedOrgId = trimTo15(orgId);
+
+  let selector: string;
+  let selectorValue: string;
+  if (options.requestId) {
+    if (
+      !options.requestId.startsWith('2vt') ||
+      !SALESFORCE_ID_PATTERN.test(options.requestId) ||
+      !validateSalesforceId(options.requestId)
+    ) {
+      throw messages.createError('invalidTrustLinkRequestId', [options.requestId]);
+    }
+    selector = `Id = '${options.requestId}'`;
+    selectorValue = options.requestId;
+  } else {
+    const authoringOrgId = options.authoringOrgId as string;
+    if (
+      !authoringOrgId.startsWith('00D') ||
+      !SALESFORCE_ID_PATTERN.test(authoringOrgId) ||
+      !validateSalesforceId(authoringOrgId)
+    ) {
+      throw messages.createError('invalidAuthoringOrgId', [authoringOrgId]);
+    }
+    selector = `AuthoringOrg = '${trimTo15(authoringOrgId)}'`;
+    selectorValue = authoringOrgId;
+  }
+
+  const query =
+    `SELECT Id, AuthoringOrg, VerifiedOrg, Status FROM ${TRUST_LINK_SOBJECT} ` +
+    `WHERE VerifiedOrg = '${verifiedOrgId}' AND OrganizationType = '${ORGANIZATION_TYPE_VERIFIED}' ` +
+    `AND AuthoringOrg != '${verifiedOrgId}' AND Status = '${requiredStatus}' AND ${selector} ORDER BY CreatedDate DESC LIMIT 1`;
+  const queryResult = await connection.autoFetchQuery<PackageTrustLinkMutationRecord>(query, { tooling: true });
+  const matchingRequest = queryResult.records?.[0];
+  if (!matchingRequest) {
+    throw messages.createError(notFoundMessage, [selectorValue]);
+  }
+
+  const updateResult = await connection.tooling.update(TRUST_LINK_SOBJECT, {
+    Id: matchingRequest.Id,
+    Status: nextStatus,
+  });
+  if (!updateResult.success) {
+    throw combineSaveErrors(TRUST_LINK_SOBJECT, 'update', updateResult.errors);
+  }
+
+  return {
+    LinkRequestId: matchingRequest.Id,
+    AuthoringOrgId: matchingRequest.AuthoringOrg,
+    VerifiedOrgId: matchingRequest.VerifiedOrg,
+    Status: nextStatus,
+  };
 }
 
 async function queryExistingTrustLink(connection: Connection): Promise<TrustLinkRecord | undefined> {

--- a/test/package/packageTrustLink.test.ts
+++ b/test/package/packageTrustLink.test.ts
@@ -535,6 +535,153 @@ describe('PackageTrustLink', () => {
     });
   });
 
+  describe('deny', () => {
+    const authoringOrgId15 = '00Dxx0000009zZZ';
+    const pendingRecord = {
+      Id: trustLinkId,
+      AuthoringOrg: authoringOrgId15,
+      VerifiedOrg: verifiedOrgId15,
+      Status: 'Pending',
+    };
+
+    it('denies a pending request selected by request ID', async () => {
+      const autoFetchQuery = sinon.stub().resolves({ records: [pendingRecord] });
+      const update = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] });
+      const connection = createConnection({
+        autoFetchQuery,
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      const result = await PackageTrustLink.deny(connection, { requestId: trustLinkId });
+
+      expect(result).to.deep.equal({
+        LinkRequestId: trustLinkId,
+        AuthoringOrgId: authoringOrgId15,
+        VerifiedOrgId: verifiedOrgId15,
+        Status: 'Declined',
+      });
+      expect(autoFetchQuery.firstCall.args[0]).to.contain("AND Status = 'Pending'");
+      expect(autoFetchQuery.firstCall.args[0]).to.contain(`AND Id = '${trustLinkId}'`);
+      expect(update.calledOnceWithExactly('PkgVrfyAuthOrgTrustRela', { Id: trustLinkId, Status: 'Declined' })).to.equal(
+        true
+      );
+    });
+
+    it('denies a pending request selected by authoring org', async () => {
+      const autoFetchQuery = sinon.stub().resolves({ records: [pendingRecord] });
+      const update = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] });
+      const connection = createConnection({
+        autoFetchQuery,
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      await PackageTrustLink.deny(connection, { authoringOrgId: '00Dxx0000009zZZEAY' });
+
+      expect(autoFetchQuery.firstCall.args[0]).to.contain(`AND AuthoringOrg = '${authoringOrgId15}'`);
+      expect(update.calledOnceWithExactly('PkgVrfyAuthOrgTrustRela', { Id: trustLinkId, Status: 'Declined' })).to.equal(
+        true
+      );
+    });
+
+    it('does not update when no pending request matches', async () => {
+      const update = sinon.stub();
+      const connection = createConnection({
+        autoFetchQuery: sinon.stub().resolves({ records: [] }),
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      try {
+        await PackageTrustLink.deny(connection, { requestId: trustLinkId });
+        expect.fail('expected a not-found error');
+      } catch (error) {
+        expect((error as Error).message).to.contain('No pending trust link request');
+      }
+      expect(update.called).to.equal(false);
+    });
+  });
+
+  describe('revoke', () => {
+    const authoringOrgId15 = '00Dxx0000009zZZ';
+    const acceptedRecord = {
+      Id: trustLinkId,
+      AuthoringOrg: authoringOrgId15,
+      VerifiedOrg: verifiedOrgId15,
+      Status: 'Accepted',
+    };
+
+    it('revokes an accepted link selected by request ID', async () => {
+      const autoFetchQuery = sinon.stub().resolves({ records: [acceptedRecord] });
+      const update = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] });
+      const connection = createConnection({
+        autoFetchQuery,
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      const result = await PackageTrustLink.revoke(connection, { requestId: trustLinkId });
+
+      expect(result).to.deep.equal({
+        LinkRequestId: trustLinkId,
+        AuthoringOrgId: authoringOrgId15,
+        VerifiedOrgId: verifiedOrgId15,
+        Status: 'Revoked',
+      });
+      expect(autoFetchQuery.firstCall.args[0]).to.contain("AND Status = 'Accepted'");
+      expect(autoFetchQuery.firstCall.args[0]).to.contain(`AND Id = '${trustLinkId}'`);
+      expect(update.calledOnceWithExactly('PkgVrfyAuthOrgTrustRela', { Id: trustLinkId, Status: 'Revoked' })).to.equal(
+        true
+      );
+    });
+
+    it('revokes an accepted link selected by authoring org', async () => {
+      const autoFetchQuery = sinon.stub().resolves({ records: [acceptedRecord] });
+      const update = sinon.stub().resolves({ success: true, id: trustLinkId, errors: [] });
+      const connection = createConnection({
+        autoFetchQuery,
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      await PackageTrustLink.revoke(connection, { authoringOrgId: '00Dxx0000009zZZEAY' });
+
+      expect(autoFetchQuery.firstCall.args[0]).to.contain(`AND AuthoringOrg = '${authoringOrgId15}'`);
+      expect(update.calledOnceWithExactly('PkgVrfyAuthOrgTrustRela', { Id: trustLinkId, Status: 'Revoked' })).to.equal(
+        true
+      );
+    });
+
+    it('does not update when no accepted link matches', async () => {
+      const update = sinon.stub();
+      const connection = createConnection({
+        autoFetchQuery: sinon.stub().resolves({ records: [] }),
+        update,
+        getApiVersion: sinon.stub().returns('68.0'),
+      });
+
+      try {
+        await PackageTrustLink.revoke(connection, { requestId: trustLinkId });
+        expect.fail('expected a not-found error');
+      } catch (error) {
+        expect((error as Error).message).to.contain('No accepted trust link');
+      }
+      expect(update.called).to.equal(false);
+    });
+
+    it('requires exactly one selector', async () => {
+      const connection = createConnection({ getApiVersion: sinon.stub().returns('68.0') });
+
+      try {
+        await PackageTrustLink.revoke(connection, {});
+        expect.fail('expected exactly-one selector validation to fail');
+      } catch (error) {
+        expect((error as Error).message).to.contain('exactly one');
+      }
+    });
+  });
+
   describe('unlink', () => {
     it('removes the existing trust link and returns its details', async () => {
       const autoFetchQuery = sinon

--- a/test/package/packageTrustLink.test.ts
+++ b/test/package/packageTrustLink.test.ts
@@ -424,11 +424,11 @@ describe('PackageTrustLink', () => {
       }
     });
 
-    it('rejects non-alphanumeric characters in a request ID', async () => {
+    it('rejects a request ID that is not a Salesforce Id', async () => {
       const connection = createConnection({ getApiVersion: sinon.stub().returns('68.0') });
 
       try {
-        await PackageTrustLink.approve(connection, { requestId: "2vtxx0000000001' '" });
+        await PackageTrustLink.approve(connection, { requestId: '2vtxx000000000' });
         expect.fail('expected request ID validation to fail');
       } catch (error) {
         expect((error as Error).message).to.contain("isn't valid");


### PR DESCRIPTION
## Summary
- add `PackageTrustLink.deny` (Pending → Declined) and `PackageTrustLink.revoke` (Accepted → Revoked) for Verified PBO admins
- reuse the approve selector path (`--request` / `--authoring-org`), scoped to the connected verified org and excluding self-trust
- match core `PkgVrfyAuthOrgTrustRela` transitions: verified org may accept or decline pending, and revoke after accept

Depends on [forcedotcom/packaging#921](https://github.com/forcedotcom/packaging/pull/921) (approve). Extra approve commits drop out once that PR merges.

## Test plan
- [x] `yarn mocha test/package/packageTrustLink.test.ts`
- [x] deny/revoke request-ID and authoring-org paths
- [x] not-found does not call Tooling update
- [x] existing approve tests still pass after shared helper extract

## Companion CLI
- deny: [salesforcecli/plugin-packaging#1279](https://github.com/salesforcecli/plugin-packaging/pull/1279)
- revoke: [salesforcecli/plugin-packaging#1278](https://github.com/salesforcecli/plugin-packaging/pull/1278)