### PR TITLE
@W-24017820@ fix(package-convert): actionable error when Dev Hub lacks 2GP

### DIFF
--- a/messages/package_version_create.md
+++ b/messages/package_version_create.md
@@ -115,6 +115,10 @@ No subscriber package was found for seed id: %s
 Only one package in a Dev Hub is allowed per converted from first-generation package, but the following were found:
 %s
 
+# convertPackagingNotEnabledOnOrg
+
+Can't convert package. The org you specified doesn't have the required second-generation packaging permission enabled. Enable this permission on your Dev Hub org, and try again.
+
 # errorMissingPackageIdOrPath
 
 You must specify either a package ID or a package path to create a new package version.

--- a/src/package/packageConvert.ts
+++ b/src/package/packageConvert.ts
@@ -65,7 +65,15 @@ export async function findOrCreatePackage2(
   project?: SfProject
 ): Promise<string> {
   const query = `SELECT Id, Name FROM Package2 WHERE ConvertedFromPackageId = '${seedPackage}'`;
-  const queryResult = (await connection.tooling.query<PackagingSObjects.Package2>(query)).records;
+  let queryResult;
+  try {
+    queryResult = (await connection.tooling.query<PackagingSObjects.Package2>(query)).records;
+  } catch (e) {
+    if (isPackage2NotSupportedError(e)) {
+      throw messages.createError('convertPackagingNotEnabledOnOrg');
+    }
+    throw e;
+  }
   if (queryResult?.length > 1) {
     const ids = queryResult.map((r) => r.Id);
     throw messages.createError('errorMoreThanOnePackage2WithSeed', [ids.join(', ')]);
@@ -100,6 +108,9 @@ export async function findOrCreatePackage2(
 
   const createResult = await connection.tooling.create('Package2', request);
   if (!createResult.success) {
+    if (createResult.errors?.some((error) => isPackage2NotSupportedError(error))) {
+      throw messages.createError('convertPackagingNotEnabledOnOrg');
+    }
     throw pkgUtils.combineSaveErrors('Package2', 'create', createResult.errors);
   }
 
@@ -475,3 +486,25 @@ const isStatusEqualTo = (
   results: PackageVersionCreateRequestResult[],
   statuses: Package2VersionStatus[] = []
 ): boolean => (!results?.length ? false : statuses.some((status) => results[0].Status === status));
+
+/**
+ * Detects the tooling-API error thrown when a Dev Hub does not have second-generation
+ * packaging enabled and the Package2 entity is therefore not accessible. The full server
+ * message may append custom-object WSDL boilerplate, so match on a substring (consistent
+ * with the handling in packageVersionRetrieve.ts).
+ *
+ * @param err the error thrown by a Package2 tooling call
+ * @returns true if the error indicates Package2 is not supported on the org
+ */
+const isPackage2NotSupportedError = (err: unknown): boolean => {
+  let msg: string;
+  if (err instanceof Error) {
+    msg = err.message;
+  } else if (typeof err === 'object' && err !== null && 'message' in err) {
+    // jsforce SaveError objects are plain objects that carry a `message` field.
+    msg = String(err.message);
+  } else {
+    msg = String(err);
+  }
+  return msg.includes("sObject type 'Package2' is not supported.");
+};

--- a/test/package/packageConvert.test.ts
+++ b/test/package/packageConvert.test.ts
@@ -650,6 +650,87 @@ describe('packageConvert', () => {
         expect((e as Error).message).to.include('No subscriber package was found for seed id: 0Ho3i000000Gmj6CAC');
       }
     });
+
+    it('will throw an actionable error when the Dev Hub does not have 2GP enabled', async () => {
+      const notSupported = new Error(
+        "sObject type 'Package2' is not supported. If you are attempting to use a custom object, be sure to append the '__c' after the entity name. Please reference your WSDL or the describe call for the appropriate names."
+      );
+      notSupported.name = 'INVALID_TYPE';
+      const conn = {
+        tooling: {
+          query: () => {
+            throw notSupported;
+          },
+        },
+      } as unknown as Connection;
+
+      try {
+        await findOrCreatePackage2('0Ho3i000000Gmj6CAC', conn);
+        expect.fail('should have thrown');
+      } catch (e) {
+        expect((e as Error).message).to.equal(
+          "Can't convert package. The org you specified doesn't have the required second-generation packaging permission enabled. Enable this permission on your Dev Hub org, and try again."
+        );
+        // the raw INVALID_TYPE text must not leak to the user
+        expect((e as Error).message).to.not.include('is not supported');
+        expect((e as Error).name).to.not.equal('INVALID_TYPE');
+      }
+    });
+
+    it('will throw an actionable error when the Package2 create reports 2GP not supported', async () => {
+      const conn = await testOrg.getConnection();
+
+      $$.SANDBOX.stub(conn.tooling, 'query')
+        .onFirstCall()
+        // @ts-ignore
+        .resolves({ records: [] })
+        .onSecondCall()
+        // @ts-ignore
+        .resolves({ records: [{ Name: 'pkg', Description: 'desc', NamespacePrefix: 'ns' }] });
+      $$.SANDBOX.stub(conn.tooling, 'create').resolves({
+        errors: [{ errorCode: 'INVALID_TYPE', message: "sObject type 'Package2' is not supported." }],
+        success: false,
+        id: undefined,
+      });
+
+      try {
+        await findOrCreatePackage2('0Ho3i000000Gmj6CAC', conn);
+        expect.fail('should have thrown');
+      } catch (e) {
+        expect((e as Error).message).to.equal(
+          "Can't convert package. The org you specified doesn't have the required second-generation packaging permission enabled. Enable this permission on your Dev Hub org, and try again."
+        );
+        expect((e as Error).message).to.not.include('is not supported');
+      }
+    });
+  });
+
+  it('convertPackage surfaces the actionable 2GP-not-enabled error', async () => {
+    const notSupported = new Error("sObject type 'Package2' is not supported.");
+    notSupported.name = 'INVALID_TYPE';
+    const conn = {
+      tooling: {
+        query: () => {
+          throw notSupported;
+        },
+      },
+    } as unknown as Connection;
+
+    try {
+      await convertPackage('0Ho3i000000Gmj6CAC', conn, {
+        buildInstance: '',
+        installationKey: '',
+        definitionfile: '',
+        installationKeyBypass: true,
+        wait: Duration.minutes(1),
+      });
+      expect.fail('should have thrown');
+    } catch (e) {
+      expect((e as Error).message).to.equal(
+        "Can't convert package. The org you specified doesn't have the required second-generation packaging permission enabled. Enable this permission on your Dev Hub org, and try again."
+      );
+      expect((e as Error).message).to.not.include('is not supported');
+    }
   });
   it('will throw correct error when create call fails', async () => {
     const conn = await testOrg.getConnection();


### PR DESCRIPTION
@W-24017820@

## What does this PR do?

Makes `sf package convert` (1GP → 2GP conversion) fail with a clear, actionable
error when run against a Dev Hub org that does not have second-generation managed
packaging enabled.

Previously, the very first server call in the convert flow — the `Package2`
tooling query in `findOrCreatePackage2` — had no error handling and did not route
through the error-massaging utilities. When the Dev Hub lacked 2GP, the raw
tooling-API error propagated straight to the user:

```
INVALID_TYPE: sObject type 'Package2' is not supported. If you are attempting to
use a custom object, be sure to append the '__c' after the entity name. Please
reference your WSDL or the describe call for the appropriate names.
```

There was no guidance telling the user the real problem: 2GP packaging isn't
enabled on their Dev Hub.

## What's the fix?

In `src/package/packageConvert.ts`:

- **Primary:** Wrap the `Package2` tooling query in `findOrCreatePackage2` in a
  `try/catch`. When the error indicates `Package2` is not supported, throw the
  new, actionable `convertPackagingNotEnabledOnOrg` message instead of the raw
  error. Any other error is rethrown unchanged.
- **Secondary:** Guard the `Package2` create path — if the create result reports
  the same "not supported" condition, throw the actionable message rather than
  the generic `combineSaveErrors` output.
- Add a small shared helper, `isPackage2NotSupportedError`, that detects the
  condition from either an `Error` or a jsforce `SaveError` object. It matches on
  a **substring** (`sObject type 'Package2' is not supported.`) because the full
  server message may append custom-object WSDL boilerplate — consistent with the
  existing handling in `packageVersionRetrieve.ts`.

New user-facing message (`messages/package_version_create.md`):

> Can't convert package. The org you specified doesn't have the required
> second-generation packaging permission enabled. Enable this permission on your
> Dev Hub org, and try again.

This mirrors the existing `packagingNotEnabledOnOrg` message used by
`sf package version retrieve`, keeping behavior consistent across commands.

## Before / After

**Before**
```
Error (INVALID_TYPE):
SELECT Id, Name FROM Package2 WHERE ConvertedFromPackageId
                     ^
ERROR at Row:1:Column:22
sObject type 'Package2' is not supported. ...
```

**After**
```
Error (ConvertPackagingNotEnabledOnOrgError): Can't convert package. The org you
specified doesn't have the required second-generation packaging permission
enabled. Enable this permission on your Dev Hub org, and try again.
```

The raw `INVALID_TYPE` / "is not supported" text no longer leaks to the user
(verified in both human-readable and `--json` output).

## Scope

This change is intentionally limited to the **convert** flow. The native
`sf package version create` path is out of scope for this PR and is unchanged.

## Testing

- Added unit tests in `test/package/packageConvert.test.ts`:
  - `findOrCreatePackage2` throws the actionable error when the `Package2` query
    fails with "not supported".
  - `findOrCreatePackage2` throws the actionable error when the `Package2`
    **create** reports "not supported".
  - `convertPackage` surfaces the actionable error (end-to-end propagation).
  - Each asserts the exact actionable message and that the raw
    `is not supported` text does not leak.
- Unit tests: `packageConvert.test.ts` — 25 passing.
- Lint and Prettier: clean on all changed files.
- **Manual end-to-end verification** against a locally-provisioned Dev Hub with
  2GP disabled: confirmed the convert command returns
  `ConvertPackagingNotEnabledOnOrgError` with no raw `INVALID_TYPE` leak in both
  default and `--json` output.

## Files changed

- `src/package/packageConvert.ts`
- `messages/package_version_create.md`
- `test/package/packageConvert.test.ts`

## Issues

@W-24017820@
